### PR TITLE
Make Job/Alt unit/abort/never/zero generic values instead of functions

### DIFF
--- a/Benchmarks/CounterActor/CounterActor.fs
+++ b/Benchmarks/CounterActor/CounterActor.fs
@@ -27,7 +27,7 @@ module ChMsg =
          (inCh >>= function
            | Add n ->
              state := !state + n
-             Job.unit ()
+             Job.unit
            | GetAndReset replyVar ->
              let was = !state
              state := 0L
@@ -71,7 +71,7 @@ module MbMsg =
          (inMb >>= function
            | Add n ->
              state := !state + n
-             Job.unit ()
+             Job.unit
            | GetAndReset replyVar ->
              let was = !state
              state := 0L

--- a/Benchmarks/ReaderWriter/ReaderWriter.fs
+++ b/Benchmarks/ReaderWriter/ReaderWriter.fs
@@ -44,7 +44,7 @@ module Tweaked =
         let rec writer i =
           iCh *<- i >>= fun () ->
           if i = 0 then
-            Job.unit ()
+            Job.unit
           else
             writer (i-1)
         let rec reader sum =

--- a/Benchmarks/Streams/Streams.fs
+++ b/Benchmarks/Streams/Streams.fs
@@ -57,14 +57,14 @@ module BasicBench =
 
      bench "ignoreWhile" 1000000 <| fun n ->
        Stream.ints n
-       |> Stream.ignoreWhile (Job.unit ())
+       |> Stream.ignoreWhile Job.unit
        |> Stream.iter |> run
 
      bench "shift" 1000000 <| fun n ->
        Stream.ints n
-       |> Stream.shift (Job.unit ())
-       |> Stream.shift (Job.unit ())
-       |> Stream.shift (Job.unit ())
+       |> Stream.shift Job.unit
+       |> Stream.shift Job.unit
+       |> Stream.shift Job.unit
        |> Stream.iter |> run
 
      bench "appendMap" 1000000 <| fun n ->
@@ -90,16 +90,16 @@ module BasicBench =
 
      bench "delayEach" 10000000 <| fun n ->
        Stream.ints n
-       |> Stream.delayEach (Job.unit ())
-       |> Stream.delayEach (Job.unit ())
-       |> Stream.delayEach (Job.unit ())
+       |> Stream.delayEach Job.unit
+       |> Stream.delayEach Job.unit
+       |> Stream.delayEach Job.unit
        |> Stream.iter |> run
 
      bench "afterEach" 10000000 <| fun n ->
        Stream.ints n
-       |> Stream.afterEach (Job.unit ())
-       |> Stream.afterEach (Job.unit ())
-       |> Stream.afterEach (Job.unit ())
+       |> Stream.afterEach Job.unit
+       |> Stream.afterEach Job.unit
+       |> Stream.afterEach Job.unit
        |> Stream.iter |> run
 
      bench "distinctUntilChanged" 10000000 <| fun n ->

--- a/Docs/Programming.md
+++ b/Docs/Programming.md
@@ -621,13 +621,13 @@ let bMoved = ref false
 do! CompareBool bMoved
                 (Ch.take ch_1)
                 (Ch.give ch_2)
-                (fun _ -> Job.unit ())
+                (fun _ -> Job.unit)
     |> Job.forever |> Job.server
 do! Delay (ref (TimeSpan.FromSeconds 3.14))
           (Ch.take ch_2)
-          (Alt.never ())
+          Alt.never
           (Ch.give ch_3)
-          (fun _ -> Job.unit ())
+          (fun _ -> Job.unit)
     |> Job.forever |> Job.server
 // ...
 ```
@@ -1335,7 +1335,7 @@ let timeReqServer =
          requests.Add (atTime, replyChs)
          replyChs
     replyIvs.Add replyCh
-    Job.unit ()
+    Job.unit
 ```
 
 The time request server also uses an asynchronous send to reply to requests.
@@ -1364,7 +1364,7 @@ let tick = Job.delay <| fun () ->
      replyChs
      |> Seq.iterJob (fun replyCh -> Ch.send replyCh ())
    | _ ->
-     Job.unit ()
+     Job.unit
 ```
 
 That concludes the implementation of the time server itself.
@@ -1414,7 +1414,7 @@ In the first case above, a verbose alternative is instantiated and committed to.
 The negative acknowledgment is created, but does not become enabled.
 
 ```fsharp
-> run <| Alt.choose [verbose <| Alt.never (); Alt.always 2] ;;
+> run <| Alt.choose [verbose Alt.never; Alt.always 2] ;;
 Instantiated and aborted.
 val it : int = 2
 ```
@@ -1566,7 +1566,7 @@ let start = Job.delay <| fun () ->
        match locks.TryGetValue lock with
         | (true, pending) ->
           pending.Enqueue (replyCh, abortAlt)
-          Job.unit ()
+          Job.unit
         | _ ->
           Alt.choose [Ch.give replyCh () ^-> fun () ->
                         locks.Add (lock, Queue<_>())
@@ -1577,7 +1577,7 @@ let start = Job.delay <| fun () ->
           let rec assign () =
             if 0 = pending.Count then
               locks.Remove lock |> ignore
-              Job.unit ()
+              Job.unit
             else
               let (replyCh, abortAlt) = pending.Dequeue ()
               Alt.choose [Ch.give replyCh ()
@@ -1585,7 +1585,7 @@ let start = Job.delay <| fun () ->
           assign ()
         | _ ->
           // We just ignore the erroneous release request
-          Job.unit ()) >>-. s
+          Job.unit) >>-. s
 ```
 
 As usual, the above server is implemented as a job that loops indefinitely

--- a/Examples/Misc/FrequencyServer.fs
+++ b/Examples/Misc/FrequencyServer.fs
@@ -54,7 +54,7 @@ let create (frequencies: seq<Frequency>) = Job.delay <| fun () ->
             <|> nack
           else
             e.Dispose ()
-            Alt.unit ()
+            Alt.unit
 
   Job.iterateServer () <| fun () ->
         if 0 < free.Count then someFree else noneFree

--- a/Examples/Misc/Kismet.fs
+++ b/Examples/Misc/Kismet.fs
@@ -39,7 +39,7 @@ module GameTime =
            requests.Add (atTime, replyIs)
            replyIs
       replyIs.Add replyI
-      Job.unit ()
+      Job.unit
 
   let tick = Job.delay <| fun () ->
     currentTime <- currentTime + 1L
@@ -49,7 +49,7 @@ module GameTime =
        replyIs
        |> Seq.iterJob (fun replyI -> replyI *<= ())
      | _ ->
-       Job.unit ()
+       Job.unit
 
 let CompareBool comparand input onTrue onFalse =
   input >>= fun x ->
@@ -75,13 +75,13 @@ let setup () = job {
   do! CompareBool <| bMoved
                   <| ch_1
                   <| fun x -> ch_2 *<- x :> Job<_>
-                  <| fun _ -> Job.unit ()
+                  <| fun _ -> Job.unit
       |> Job.foreverServer
   do! Delay <| ref 314L
             <| ch_2
-            <| Alt.never ()
+            <| Alt.never
             <| Ch.give ch_3
-            <| fun _ -> Job.unit ()
+            <| fun _ -> Job.unit
       |> Job.foreverServer
   // ...
 }

--- a/Examples/Misc/LockServer.fs
+++ b/Examples/Misc/LockServer.fs
@@ -46,7 +46,7 @@ let start = Job.delay <| fun () ->
        match locks.TryGetValue lock with
         | (true, pending) ->
           pending.Enqueue (replyCh, abortAlt)
-          Alt.unit ()
+          Alt.unit
         | _ ->
               replyCh *<- () ^-> fun () ->
                 locks.Add (lock, Queue ())
@@ -57,13 +57,13 @@ let start = Job.delay <| fun () ->
           let rec assign () =
             if 0 = pending.Count then
               locks.Remove lock |> ignore
-              Alt.unit ()
+              Alt.unit
             else
               let (replyCh, abortAlt) = pending.Dequeue ()
               replyCh *<- () <|> abortAlt ^=> assign
           assign ()
         | _ ->
           // We just ignore the erroneous release request
-          Alt.unit ()
+          Alt.unit
   |> Job.foreverServer
   >>-. s

--- a/Libs/Hopac.Experimental/Alts.fs
+++ b/Libs/Hopac.Experimental/Alts.fs
@@ -19,19 +19,19 @@ module Alts =
 
   let consume (onNext: 'x -> Job<unit>) (In xO: Alts<'x>) : Job<unit> =
     let rec loop xO =
-      xO >>= function Done -> Job.unit ()
+      xO >>= function Done -> Job.unit
                     | Next (x, xO) -> onNext x >>= fun () -> loop xO
     loop xO
 
   // Primitives ----------------------------------------------------------------
 
-  let zero () : Alts<'x> = In <| Alt.always Done
+  let zero<'x> : Alts<'x> = In <| Alt.always Done
 
   let result x : Alts<'x> = In <| Alt.always (Next (x, Alt.always Done))
 
   let inline start f =
     Alt.withNackJob <| fun nack ->
-    Promise.start (f (nack ^=> Job.abort))
+    Promise.start (f (nack ^=>. Job.abort))
 
   let rec mergeAbort yO1 yO2 abort =
     let inline case yO1 yO2 =

--- a/Libs/Hopac.Experimental/Alts.fsi
+++ b/Libs/Hopac.Experimental/Alts.fsi
@@ -12,7 +12,7 @@ type Alts<'x>
 module Alts =
   val consume: onNext: ('x -> Job<unit>) -> Alts<'x> -> Job<unit>
 
-  val zero: unit -> Alts<'x>
+  val zero<'x> : Alts<'x>
 
   val result: 'x -> Alts<'x>
 

--- a/Libs/Hopac.Experimental/Discrete.fs
+++ b/Libs/Hopac.Experimental/Discrete.fs
@@ -13,7 +13,7 @@ module Alt =
 
     let start (abort2xJ: Alt<'x> -> #Job<'x>) : Alt<'x> =
       Alt.withNackJob <| fun nack ->
-      Promise.queue (abort2xJ (nack ^=> Job.abort))
+      Promise.queue (abort2xJ (nack ^=>. Job.abort))
 
     let merge (lhs: Alt<'x>) (rhs: Alt<'x>) =
       start <| fun abort -> lhs <|> rhs <|> abort
@@ -37,7 +37,7 @@ module Alt =
       xA
       |> switchMap (fun x ->
          match x2yO x with
-          | None -> Alt.never ()
+          | None -> Alt.never
           | Some y -> Alt.once y)
 
     let filter x2b xA =

--- a/Libs/Hopac.Experimental/EagerSeq.fs
+++ b/Libs/Hopac.Experimental/EagerSeq.fs
@@ -110,12 +110,12 @@ module EagerSeq =
     Job.queue (loop xs.EagerSeq) >>-. xs
 
   let rec iterFun (x2u: 'x -> unit) (xs: EagerSeq<'x>) =
-    xs.EagerSeq >>= function None -> Job.unit ()
+    xs.EagerSeq >>= function None -> Job.unit
                            | Some (x, xs) -> x2u x ; iterFun x2u xs
 
   let rec iterJob (x2yJ: 'x -> Job<'y>) (xs: EagerSeq<'x>) =
     xs.EagerSeq >>= function
-     | None -> Job.unit ()
+     | None -> Job.unit
      | Some (x, xs) -> x2yJ x >>= fun _ -> iterJob x2yJ xs
 
   let mapFun (x2y: 'x -> 'y) xs =

--- a/Libs/Hopac.Extra/IMap.fs
+++ b/Libs/Hopac.Extra/IMap.fs
@@ -47,7 +47,7 @@ module IMap =
     match k2vI.TryGetValue k with
      | (false, _) ->
        k2vI.Add (k, IVar.Now.createFull (Some v))
-       Job.unit ()
+       Job.unit
      | (true, vI) ->
        if IVar.Now.isFull vI then
          failwithf "Tried to fill item %A twice." k

--- a/Libs/Hopac.Extra/Stream.fs
+++ b/Libs/Hopac.Extra/Stream.fs
@@ -15,13 +15,13 @@ module Stream =
 
   let filterFun x2b (xIn: In<_>) (xOut: Out<_>) =
     Job.foreverServer
-     (xIn >>= fun x -> if x2b x then xOut x else Job.unit ())
+     (xIn >>= fun x -> if x2b x then xOut x else Job.unit)
 
   let filterJob (x2bJ: 'x -> #Job<_>) (xIn: In<_>) (xOut: Out<_>) =
     Job.foreverServer
      (xIn >>= fun x ->
       x2bJ x >>= fun b ->
-      if b then xOut x else Job.unit ())
+      if b then xOut x else Job.unit)
 
   let iterateFun x x2x (xOut: Out<_>) =
     Job.iterateServer x (fun x -> xOut x >>-. x2x x)

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -453,14 +453,14 @@ open Infixes
 module Alt =
   let inline always (x: 'x) = Always<'x> (x) :> Alt<'x>
 
-  let inline unit () =
+  let unit =
     match StaticData.unit with
      | null -> StaticData.Init () ; StaticData.unit
      | unit -> unit
 
-  let inline never () = Never<_>() :> Alt<_>
+  let never<'x> = Never<'x>() :> Alt<_>
 
-  let inline zero () =
+  let zero =
     match StaticData.zero with
      | null -> StaticData.Init () ; StaticData.zero :> Alt<_>
      | zero -> zero :> Alt<_>
@@ -623,7 +623,7 @@ module Alt =
            else
              xE.TryElse (&wr, i)}.Init(xE.pk))}
     else
-      never ()
+      never
 
   let inline shuffle (wr: byref<Worker>) (xAs: array<_>) j =
     let j' = Randomizer.NextInRange (&wr.RandomLo, &wr.RandomHi, j, xAs.Length)
@@ -1052,14 +1052,14 @@ module Job =
     {new JobMap<'x, 'y> () with
       override yJ'.Do (x) = x2y x}.InternalInit(xJ)
 
-  let inline unit () = Alt.unit () :> Job<_>
+  let unit = Alt.unit :> Job<_>
 
-  let abort () = Never<_>() :> Job<_>
+  let abort<'x> = Never<'x>() :> Job<_>
 
   let raises (e: exn) = Raises (e) :> Job<_>
 
   let inline whenDo (b: bool) (uJ: Job<unit>) =
-    if b then uJ else unit ()
+    if b then uJ else unit
 
   //////////////////////////////////////////////////////////////////////////////
 
@@ -1553,8 +1553,7 @@ module Promise =
     let inline delay (xJ: Job<'x>) = Promise<'x> (xJ)
     let inline withValue (x: 'x) = Promise<'x> (x)
     let inline withFailure (e: exn) = Promise<'x> (e)
-    [<MethodImpl(MethodImplOptions.NoInlining)>]
-    let never () = let p = Promise<'x> () in p.State <- Promise<'x>.Running ; p
+    let never<'x> = let p = Promise<'x> () in p.State <- Promise<'x>.Running ; p
     [<MethodImpl(MethodImplOptions.NoInlining)>]
     let isFulfilled (xP: Promise<'x>) = xP.Full
     [<MethodImpl(MethodImplOptions.NoInlining)>]
@@ -1640,9 +1639,9 @@ module Timer =
       let ms = (ticks + 9999L) / 10000L // Rounds up.
       if ticks <= 0L then
         if -10000L = ticks then
-          Alt.zero ()
+          Alt.zero
         elif 0L = ticks then
-          Alt.unit ()
+          Alt.unit
         else
           outOfRange ticks
       elif 21474836470000L < ticks then
@@ -2228,7 +2227,7 @@ type JobBuilder () =
     Job.using x x2yJ
   member inline job.While (u2b: unit -> bool, uJ: Job<unit>) : Job<unit> =
     Job.whileDo u2b uJ
-  member inline job.Zero () : Job<unit> = Job.unit ()
+  member inline job.Zero () : Job<unit> = Job.unit
 
 type EmbeddedJob<'x> = struct
     val Job: Job<'x>

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -99,7 +99,7 @@ type IAsyncDisposable =
   /// Note that simply calling `DisposeAsync` must not immediately dispose the
   /// resource.  For example, the following pattern is incorrect:
   ///
-  ///> override this.DisposeAsync () = this.DisposeFlag <- true ; Job.unit ()
+  ///> override this.DisposeAsync () = this.DisposeFlag <- true ; Job.unit
   ///
   /// A typical correct disposal pattern could look something like this:
   ///
@@ -542,9 +542,9 @@ module Job =
 
   //////////////////////////////////////////////////////////////////////////////
 
-  /// Returns a job that does nothing and returns `()`.  `unit ()` is an
+  /// A job that does nothing and returns `()`.  `unit` is an
   /// optimized version of `result ()`.
-  val inline unit: unit -> Job<unit>
+  val unit: Job<unit>
 
   /// Creates a job with the given result.  See also: `lift`, `thunk`, `unit`.
   val result: 'x -> Job<'x>
@@ -561,7 +561,7 @@ module Job =
   /// the given function.  This is the same as `>>-` with the arguments flipped.
   val inline map: ('x -> 'y) -> Job<'x> -> Job<'y>
 
-  /// Creates a job that immediately terminates the current job.  See also:
+  /// A job that immediately terminates the current job.  See also:
   /// `startWithFinalizer`.
 #if DOC
   ///
@@ -573,7 +573,7 @@ module Job =
   /// or `tryFinallyJob`, the job must either return normally or raise an
   /// exception.  In other words, do not use `abort` in such a case.
 #endif
-  val abort: unit -> Job<_>
+  val abort<'x> : Job<'x>
 
   /// Creates a job that has the effect of raising the specified exception.
   /// `raises e` is equivalent to `Job.delayWith raise e`.
@@ -736,7 +736,7 @@ module Job =
   ///>   if n > 0 then
   ///>     uJ >>= fun () -> forN (n - 1) uJ
   ///>   else
-  ///>     Job.unit ()
+  ///>     Job.unit
 #endif
   val inline forN:       int -> Job<unit> -> Job<unit>
 
@@ -754,7 +754,7 @@ module Job =
   ///>   if lo <= hi then
   ///>     i2uJ lo >>= fun () -> forUpTo (lo + 1) hi i2uJ
   ///>   else
-  ///>     Job.unit ()
+  ///>     Job.unit
   ///
   /// Rationale: The reason for iterating over an inclusive range is to make
   /// this construct work like a `for ... to ... do ...` loop of the base F#
@@ -777,7 +777,7 @@ module Job =
   ///>   if hi >= lo then
   ///>     i2uJ hi >>= fun () -> forDownTo (hi - 1) lo i2uJ
   ///>   else
-  ///>     Job.unit ()
+  ///>     Job.unit
   ///
   /// Rationale: The reason for iterating over an inclusive range is to make
   /// this construct work like a `for ... downto ... do ...` loop of the base F#
@@ -800,7 +800,7 @@ module Job =
   ///>     if u2b () then
   ///>       uJ >>= loop
   ///>     else
-  ///>       Job.unit ()
+  ///>       Job.unit
   ///>   loop ()
 #endif
   val inline whileDo:       (unit -> bool) ->           Job<unit> -> Job<unit>
@@ -814,7 +814,7 @@ module Job =
   /// equivalent to `Job.Ignore xJ |> whileDo u2b`.
   val inline whileDoIgnore: (unit -> bool) ->           Job<_>    -> Job<unit>
 
-  /// `whenDo b uJ` is equivalent to `if b then uJ else Job.unit ()`.
+  /// `whenDo b uJ` is equivalent to `if b then uJ else Job.unit`.
   val inline whenDo: bool -> Job<unit> -> Job<unit>
 
   //////////////////////////////////////////////////////////////////////////////
@@ -1104,19 +1104,19 @@ module Alt =
   /// the first such alternative will be committed to.
   val inline always: 'x -> Alt<'x>
 
-  /// Returns an alternative that is always available and results in the unit
-  /// value.  `unit ()` is an optimized version of `always ()`.
-  val inline unit: unit -> Alt<unit>
+  /// An alternative that is always available and results in the unit
+  /// value.  `unit` is an optimized version of `always ()`.
+  val unit: Alt<unit>
 
-  /// Creates an alternative that is never available.
+  /// An alternative that is never available.
   ///
-  /// Note that synchronizing on `never ()`, without other alternatives, is
-  /// equivalent to performing `abort ()`.
-  val inline never: unit -> Alt<'x>
+  /// Note that synchronizing on `never`, without other alternatives, is
+  /// equivalent to performing `abort`.
+  val never<'x> : Alt<'x>
 
-  /// Returns an alternative that is never available.  `zero ()` is an optimized
-  /// version of `never ()`.
-  val inline zero: unit -> Alt<unit>
+  /// An alternative that is never available.  `zero` is an optimized
+  /// version of `never`.
+  val zero: Alt<unit>
 
   /// Returns an alternative that can be committed to once and that produces the
   /// given value.
@@ -1275,13 +1275,13 @@ module Alt =
   /// Creates an alternative that is available when any one of the given
   /// alternatives is.  See also: `choosy`, `<|>`.
   ///
-  /// Note that `choose []` is equivalent to `never ()`.
+  /// Note that `choose []` is equivalent to `never`.
 #if DOC
   ///
   /// Reference implementation:
   ///
   ///> let choose xAs = Alt.prepareFun <| fun () ->
-  ///>   Seq.foldBack (<|>) xAs <| never ()
+  ///>   Seq.foldBack (<|>) xAs never
   ///
   /// Above, `Seq.foldBack` has the obvious meaning.  Alternatively we could
   /// define `xA1 <|> xA2` to be equivalent to `choose [xA1; xA2]` and consider
@@ -1972,7 +1972,7 @@ module Promise =
     val inline withFailure: exn -> Promise<'x>
 
     /// Creates a promise that will never be fulfilled.
-    val never: unit -> Promise<'x>
+    val never<'x> : Promise<'x>
 
     /// Returns true iff the given promise has already been fulfilled (either
     /// with a value or with a failure).

--- a/Libs/Hopac/Stream.fsi
+++ b/Libs/Hopac/Stream.fsi
@@ -279,7 +279,7 @@ module Stream =
   /// A choice stream that never produces any values and never closes.  While
   /// perhaps rarely used, this is theoretically important as the identity
   /// element for the `switch` and `amb` combinators.
-  val inline never<'x> : Stream<'x>
+  val never<'x> : Stream<'x>
 
   /// Constructs a choice stream that is closed with an error.
   val inline error: exn -> Stream<'x>
@@ -1052,7 +1052,7 @@ module Stream =
   /// Reference implementation:
   ///
   ///> let rec iterJob x2uJ xs =
-  ///>   xs >>= function Nil -> Job.unit ()
+  ///>   xs >>= function Nil -> Job.unit
   ///>                 | Cons (x, xs) -> x2uJ x >>=. iterJob x2uJ xs
 #endif
   val iterJob: ('x -> #Job<unit>) -> Stream<'x> -> Job<unit>


### PR DESCRIPTION
The `Job.unit`, `Job.abort`, `Alt.unit`, `Alt.never`, `Alt.zero`, `Alts.zero`, and `Stream.never` API members can be reduced from unit functions to values. This reduces the number of objects created for these simple primitives.

Includes changes to the XMLdoc related to the change.
