### PR TITLE
WIP: Improving Job/Alt <=> Task/Async interop.

### DIFF
--- a/Libs/Hopac.Core/External/BeginEnd.cs
+++ b/Libs/Hopac.Core/External/BeginEnd.cs
@@ -30,7 +30,7 @@ namespace Hopac.Core {
       xK.DoHandle(ref wr, e);
     }
     internal override void DoWork(ref Worker wr) {
-      xK.DoCont(ref wr, xJ.DoEnd(iar));
+      Cont.Do(xK, ref wr, xJ.DoEnd(iar));
     }
     internal override void DoCont(ref Worker wr, Unit value) {
       this.DoWork(ref wr);
@@ -51,7 +51,7 @@ namespace Hopac.Core {
       if (0 != Pick.PickAndSetNacks(pk, ref wr, me))
         xJ.DoCancel(iar);
       else
-        xK.DoCont(ref wr, xJ.DoEnd(iar));
+        Cont.Do(xK, ref wr, xJ.DoEnd(iar));
     }
   }
 

--- a/Libs/Hopac.Core/External/BeginEnd.cs
+++ b/Libs/Hopac.Core/External/BeginEnd.cs
@@ -2,44 +2,94 @@
 
 namespace Hopac.Core {
   using System;
+  using System.Threading;
+  using Microsoft.FSharp.Core;
 
-  internal abstract class WorkAsyncCallback : Work {
+  internal abstract class WorkAsyncCallback : Cont<Unit> {
     internal abstract void Ready(IAsyncResult iar);
   }
 
+  internal class JobCallback<X> : WorkAsyncCallback {
+    internal Scheduler sr;
+    internal FromBeginEnd<X> xJ;
+    internal Cont<X> xK;
+    internal IAsyncResult iar;
+    internal JobCallback(Scheduler sr, FromBeginEnd<X> xJ, Cont<X> xK) {
+      this.sr = sr;
+      this.xJ = xJ;
+      this.xK = xK;
+    }
+    internal override void Ready(IAsyncResult iar) {
+      this.iar = iar;
+      Worker.RunOnThisThread(sr, this);
+    }
+    internal override Proc GetProc(ref Worker wr) {
+      return xK.GetProc(ref wr);
+    }
+    internal override void DoHandle(ref Worker wr, Exception e) {
+      xK.DoHandle(ref wr, e);
+    }
+    internal override void DoWork(ref Worker wr) {
+      xK.DoCont(ref wr, xJ.DoEnd(iar));
+    }
+    internal override void DoCont(ref Worker wr, Unit value) {
+      this.DoWork(ref wr);
+    }
+  }
+
+  internal class AltCallback<X> : JobCallback<X> {
+    internal Pick pk;
+    internal volatile int me;
+    internal AltCallback(Scheduler sr, FromBeginEnd<X> xJ, Cont<X> xK, Pick pk, int me) : base(sr, xJ, xK) {
+      this.pk = pk;
+      this.me = me;
+    }
+    internal override void DoWork(ref Worker wr) {
+      var me = this.me;
+      if (me < 0 && me == Interlocked.CompareExchange(ref this.me, 0, me))
+        return;
+      if (0 != Pick.PickAndSetNacks(pk, ref wr, me))
+        xJ.DoCancel(iar);
+      else
+        xK.DoCont(ref wr, xJ.DoEnd(iar));
+    }
+  }
+
   ///
-  public abstract class JobFromBeginEnd<X> : Job<X> {
+  public abstract class FromBeginEnd<X> : Alt<X> {
     ///
     public abstract IAsyncResult DoBegin(AsyncCallback acb, object state);
     ///
     public abstract X DoEnd(IAsyncResult iar);
-
-    private class Callback : WorkAsyncCallback {
-      private Scheduler sr;
-      private JobFromBeginEnd<X> xJ;
-      private Cont<X> xK;
-      private IAsyncResult iar;
-      internal Callback(Scheduler sr, JobFromBeginEnd<X> xJ, Cont<X> xK) {
-        this.sr = sr;
-        this.xJ = xJ;
-        this.xK = xK;
-      }
-      internal override void Ready(IAsyncResult iar) {
-        this.iar = iar;
-        Worker.RunOnThisThread(sr, this);
-      }
-      internal override Proc GetProc(ref Worker wr) {
-        return xK.GetProc(ref wr);
-      }
-      internal override void DoHandle(ref Worker wr, Exception e) {
-        xK.DoHandle(ref wr, e);
-      }
-      internal override void DoWork(ref Worker wr) {
-        xK.DoCont(ref wr, xJ.DoEnd(iar));
-      }
-    }
+    ///
+    public virtual void DoCancel(IAsyncResult iar) {}
     internal override void DoJob(ref Worker wr, Cont<X> xK) {
-      DoBegin(StaticData.workAsyncCallback, new Callback(wr.Scheduler, this, xK));
+      DoBegin(StaticData.workAsyncCallback, new JobCallback<X>(wr.Scheduler, this, xK));
+    }
+    internal override void TryAlt(ref Worker wr, int i, Cont<X> xK, Else xE) {
+      var pk = xE.pk;
+      var cb = new AltCallback<X>(wr.Scheduler, this, xK, pk, -1);
+      var nk = Pick.ClaimAndAddNack(pk, i);
+      if (null != nk) {
+        try {
+          cb.iar = DoBegin(StaticData.workAsyncCallback, cb);
+        } catch (Exception e) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          Handler.DoHandle(xK, ref wr, e);
+          return;
+        }
+        var m = cb.me;
+        if (0 <= m || m != Interlocked.CompareExchange(ref cb.me, i, m)) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          Cont.Do(xK, ref wr, DoEnd(cb.iar));
+        } else {
+          nk.UnsafeAddReader(cb);
+          Pick.Unclaim(pk);
+          var j = i + 1;
+          nk.I1 = j;
+          xE.TryElse(ref wr, j);
+        }
+      }
     }
   }
 }

--- a/Libs/Hopac.Core/External/Tasks.cs
+++ b/Libs/Hopac.Core/External/Tasks.cs
@@ -8,7 +8,7 @@ namespace Hopac.Core {
   using System.Threading.Tasks;
 
   ///
-  public abstract class BindTaskWithResult<X, Y> : Job<Y> {
+  public abstract class BindTask<X, Y> : Job<Y> {
     private Task<X> xT;
     ///
     [MethodImpl(AggressiveInlining.Flag)]
@@ -17,9 +17,9 @@ namespace Hopac.Core {
     public abstract Job<Y> Do(X x);
     private sealed class State : Work {
       private Scheduler sr;
-      private BindTaskWithResult<X, Y> yJ;
+      private BindTask<X, Y> yJ;
       private Cont<Y> yK;
-      internal State(Scheduler sr, BindTaskWithResult<X, Y> yJ, Cont<Y> yK) {
+      internal State(Scheduler sr, BindTask<X, Y> yJ, Cont<Y> yK) {
         this.sr = sr;
         this.yJ = yJ;
         this.yK = yK;
@@ -91,40 +91,68 @@ namespace Hopac.Core {
     }
   }
 
+  internal sealed class TaskToJobAwaiter<X> : Work {
+    private Task<X> xT;
+    private Cont<X> xK;
+    private Scheduler sr;
+    [MethodImpl(AggressiveInlining.Flag)]
+    public TaskToJobAwaiter(Task<X> xT, Cont<X> xK, Scheduler sr) {
+      this.xT = xT;
+      this.xK = xK;
+      this.sr = sr;
+    }
+    internal override Proc GetProc(ref Worker wr) {
+      return xK.GetProc(ref wr);
+    }
+    internal override void DoHandle(ref Worker wr, Exception e) {
+      xK.DoHandle(ref wr, e);
+    }
+    internal override void DoWork(ref Worker wr) {
+      xK.DoCont(ref wr, xT.Result);
+    }
+    public void Ready() {
+      Worker.RunOnThisThread(this.sr, this);
+    }
+  }
+
   ///
-  public abstract class TaskWithResultToJob<X> : Job<X> {
+  public abstract class TaskToJob<X> : Job<X> {
     ///
     public abstract Task<X> Start();
-    ///
-    private sealed class State : Work {
-      private Task<X> xT;
-      private Cont<X> xK;
-      private Scheduler sr;
-      [MethodImpl(AggressiveInlining.Flag)]
-      public State(Task<X> xT, Cont<X> xK, Scheduler sr) {
-        this.xT = xT;
-        this.xK = xK;
-        this.sr = sr;
-      }
-      internal override Proc GetProc(ref Worker wr) {
-        return xK.GetProc(ref wr);
-      }
-      internal override void DoHandle(ref Worker wr, Exception e) {
-        xK.DoHandle(ref wr, e);
-      }
-      internal override void DoWork(ref Worker wr) {
-        xK.DoCont(ref wr, xT.Result);
-      }
-      public void Ready() {
-        Worker.RunOnThisThread(this.sr, this);
-      }
-    }
     internal override void DoJob(ref Worker wr, Cont<X> xK) {
       var xT = this.Start();
       if (TaskStatus.RanToCompletion == xT.Status)
         Cont.Do(xK, ref wr, xT.Result);
       else
-        xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new State(xT, xK, wr.Scheduler).Ready);
+        xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new TaskToJobAwaiter<X>(xT, xK, wr.Scheduler).Ready);
+    }
+  }
+
+  internal sealed class TaskToJobAwaiter : Work {
+    private Task uT;
+    private Cont<Unit> uK;
+    private Scheduler sr;
+    [MethodImpl(AggressiveInlining.Flag)]
+    public TaskToJobAwaiter(Task uT, Cont<Unit> uK, Scheduler sr) {
+      this.uT = uT;
+      this.uK = uK;
+      this.sr = sr;
+    }
+    internal override Proc GetProc(ref Worker wr) {
+      return uK.GetProc(ref wr);
+    }
+    internal override void DoHandle(ref Worker wr, Exception e) {
+      uK.DoHandle(ref wr, e);
+    }
+    internal override void DoWork(ref Worker wr) {
+      var uT = this.uT;
+      if (TaskStatus.RanToCompletion == uT.Status)
+        uK.DoWork(ref wr);
+      else
+        uK.DoHandle(ref wr, uT.Exception);
+    }
+    internal void Ready() {
+      Worker.RunOnThisThread(this.sr, this);
     }
   }
 
@@ -132,107 +160,74 @@ namespace Hopac.Core {
   public abstract class TaskToJob : Job<Unit> {
     ///
     public abstract Task Start();
-    ///
-    private sealed class State : Work {
-      private Task uT;
-      private Cont<Unit> uK;
-      private Scheduler sr;
-      [MethodImpl(AggressiveInlining.Flag)]
-      public State(Task uT, Cont<Unit> uK, Scheduler sr) {
-        this.uT = uT;
-        this.uK = uK;
-        this.sr = sr;
-      }
-      internal override Proc GetProc(ref Worker wr) {
-        return uK.GetProc(ref wr);
-      }
-      internal override void DoHandle(ref Worker wr, Exception e) {
-        uK.DoHandle(ref wr, e);
-      }
-      internal override void DoWork(ref Worker wr) {
-        var uT = this.uT;
-        if (TaskStatus.RanToCompletion == uT.Status)
-          uK.DoWork(ref wr);
-        else
-          uK.DoHandle(ref wr, uT.Exception);
-      }
-      internal void Ready() {
-        Worker.RunOnThisThread(this.sr, this);
-      }
-    }
     internal override void DoJob(ref Worker wr, Cont<Unit> uK) {
       var uT = this.Start();
       if (TaskStatus.RanToCompletion == uT.Status)
         Work.Do(uK, ref wr);
       else
-        uT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new State(uT, uK, wr.Scheduler).Ready);
+        uT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new TaskToJobAwaiter(uT, uK, wr.Scheduler).Ready);
+    }
+  }
+
+  internal sealed class TaskToAltAwaiter<X> : Cont<Unit> {
+    private CancellationTokenSource cts;
+    private Pick pk;
+    private int me;
+    private Task<X> xT;
+    private Cont<X> xK;
+    private Scheduler sr;
+    [MethodImpl(AggressiveInlining.Flag)]
+    public TaskToAltAwaiter(CancellationTokenSource cts, Pick pk, int me, Task<X> xT, Cont<X> xK, Scheduler sr) {
+      this.cts = cts;
+      this.pk = pk;
+      this.me = me;
+      this.xT = xT;
+      this.xK = xK;
+      this.sr = sr;
+    }
+    internal override Proc GetProc(ref Worker wr) {
+      return xK.GetProc(ref wr);
+    }
+    internal override void DoHandle(ref Worker wr, Exception e) {
+      xK.DoHandle(ref wr, e);
+    }
+    internal override void DoWork(ref Worker wr) {
+      var pk = this.pk;
+      if (null == pk)
+        goto DoCont;
+      var cts = this.cts;
+      if (null == cts)
+        goto Done;
+      this.cts = null;
+      var picked = Pick.PickAndSetNacks(pk, ref wr, this.me);
+      if (0 != picked)
+        cts.Cancel();
+      cts.Dispose();
+      if (0 != picked)
+        goto Done;
+    DoCont:
+      xK.DoCont(ref wr, xT.Result);
+    Done:
+      return;
+    }
+    internal override void DoCont(ref Worker wr, Unit value) {
+      this.DoWork(ref wr);
+    }
+    public void Ready() {
+      Worker.RunOnThisThread(this.sr, this);
     }
   }
 
   ///
-  public abstract class TaskWithResultToAlt<X> : Alt<X> {
+  public abstract class TaskToAlt<X> : Alt<X> {
     ///
     public abstract Task<X> Start(CancellationToken t);
-    private sealed class State : Cont<Unit> {
-      private CancellationTokenSource cts;
-      private Pick pk;
-      private int me;
-      private Task<X> xT;
-      private Cont<X> xK;
-      private Scheduler sr;
-      [MethodImpl(AggressiveInlining.Flag)]
-      public State(CancellationTokenSource cts, Pick pk, int me, Task<X> xT, Cont<X> xK, Scheduler sr) {
-        this.cts = cts;
-        this.pk = pk;
-        this.me = me;
-        this.xT = xT;
-        this.xK = xK;
-        this.sr = sr;
-      }
-      [MethodImpl(AggressiveInlining.Flag)]
-      public State(Task<X> xT, Cont<X> xK, Scheduler sr) {
-        this.xT = xT;
-        this.xK = xK;
-        this.sr = sr;
-      }
-      internal override Proc GetProc(ref Worker wr) {
-        return xK.GetProc(ref wr);
-      }
-      internal override void DoHandle(ref Worker wr, Exception e) {
-        xK.DoHandle(ref wr, e);
-      }
-      internal override void DoWork(ref Worker wr) {
-        var pk = this.pk;
-        if (null == pk)
-          goto DoCont;
-        var cts = this.cts;
-        if (null == cts)
-          goto Done;
-        this.cts = null;
-        var picked = Pick.PickAndSetNacks(pk, ref wr, this.me);
-        if (0 != picked)
-          cts.Cancel();
-        cts.Dispose();
-        if (0 != picked)
-          goto Done;
-      DoCont:
-        xK.DoCont(ref wr, xT.Result);
-      Done:
-        return;
-      }
-      internal override void DoCont(ref Worker wr, Unit value) {
-        this.DoWork(ref wr);
-      }
-      public void Ready() {
-        Worker.RunOnThisThread(this.sr, this);
-      }
-    }
     internal override void DoJob(ref Worker wr, Cont<X> xK) {
       var xT = Start(new CancellationToken(false));
       if (TaskStatus.RanToCompletion == xT.Status)
         Cont.Do(xK, ref wr, xT.Result);
       else
-        xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new State(xT, xK, wr.Scheduler).Ready);
+        xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new TaskToJobAwaiter<X>(xT, xK, wr.Scheduler).Ready);
     }
     internal override void TryAlt(ref Worker wr, int i, Cont<X> xK, Else xE) {
       var pk = xE.pk;
@@ -253,13 +248,107 @@ namespace Hopac.Core {
           cts.Dispose();
           Cont.Do(xK, ref wr, xT.Result);
         } else {
-          var state = new State(cts, pk, i, xT, xK, wr.Scheduler);
+          var state = new TaskToAltAwaiter<X>(cts, pk, i, xT, xK, wr.Scheduler);
           nk.UnsafeAddReader(state);
           Pick.Unclaim(pk);
           var j = i + 1;
           nk.I1 = j;
           xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(state.Ready);
           xE.TryElse(ref wr, j);
+        }
+      }
+    }
+  }
+
+  internal sealed class TaskToAltAwaiter : Cont<Unit> {
+    private CancellationTokenSource cts;
+    private Pick pk;
+    private int me;
+    private Task uT;
+    private Cont<Unit> uK;
+    private Scheduler sr;
+    [MethodImpl(AggressiveInlining.Flag)]
+    public TaskToAltAwaiter(CancellationTokenSource cts, Pick pk, int me, Task uT, Cont<Unit> uK, Scheduler sr) {
+      this.cts = cts;
+      this.pk = pk;
+      this.me = me;
+      this.uT = uT;
+      this.uK = uK;
+      this.sr = sr;
+    }
+    internal override Proc GetProc(ref Worker wr) {
+      return uK.GetProc(ref wr);
+    }
+    internal override void DoHandle(ref Worker wr, Exception e) {
+      uK.DoHandle(ref wr, e);
+    }
+    internal override void DoWork(ref Worker wr) {
+      var pk = this.pk;
+      if (null == pk)
+        goto DoCont;
+      var cts = this.cts;
+      if (null == cts)
+        goto Done;
+      this.cts = null;
+      var picked = Pick.PickAndSetNacks(pk, ref wr, this.me);
+      if (0 != picked)
+        cts.Cancel();
+      cts.Dispose();
+      if (0 != picked)
+        goto Done;
+    DoCont:
+      if (TaskStatus.RanToCompletion == uT.Status)
+        uK.DoWork(ref wr);
+      else
+        uK.DoHandle(ref wr, uT.Exception);
+    Done:
+      return;
+    }
+    internal override void DoCont(ref Worker wr, Unit value) {
+      this.DoWork(ref wr);
+    }
+    public void Ready() {
+      Worker.RunOnThisThread(this.sr, this);
+    }
+  }
+
+  ///
+  public abstract class TaskToAlt : Alt<Unit> {
+    ///
+    public abstract Task Start(CancellationToken t);
+    internal override void DoJob(ref Worker wr, Cont<Unit> uK) {
+      var uT = Start(new CancellationToken(false));
+      if (TaskStatus.RanToCompletion == uT.Status)
+        Work.Do(uK, ref wr);
+      else
+        uT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new TaskToJobAwaiter(uT, uK, wr.Scheduler).Ready);
+    }
+    internal override void TryAlt(ref Worker wr, int i, Cont<Unit> uK, Else uE) {
+      var pk = uE.pk;
+      var nk = Pick.ClaimAndAddNack(pk, i);
+      if (null != nk) {
+        var cts = new CancellationTokenSource();
+        Task uT;
+        try {
+          uT = this.Start(cts.Token);
+        } catch (Exception e) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          cts.Dispose();
+          Handler.DoHandle(uK, ref wr, e);
+          return;
+        }
+        if (TaskStatus.RanToCompletion == uT.Status) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          cts.Dispose();
+          Work.Do(uK, ref wr);
+        } else {
+          var state = new TaskToAltAwaiter(cts, pk, i, uT, uK, wr.Scheduler);
+          nk.UnsafeAddReader(state);
+          Pick.Unclaim(pk);
+          var j = i + 1;
+          nk.I1 = j;
+          uT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(state.Ready);
+          uE.TryElse(ref wr, j);
         }
       }
     }

--- a/Libs/Hopac.Core/External/Tasks.cs
+++ b/Libs/Hopac.Core/External/Tasks.cs
@@ -193,8 +193,6 @@ namespace Hopac.Core {
     }
     internal override void DoWork(ref Worker wr) {
       var pk = this.pk;
-      if (null == pk)
-        goto DoCont;
       var cts = this.cts;
       if (null == cts)
         goto Done;
@@ -205,7 +203,6 @@ namespace Hopac.Core {
       cts.Dispose();
       if (0 != picked)
         goto Done;
-    DoCont:
       xK.DoCont(ref wr, xT.Result);
     Done:
       return;
@@ -284,8 +281,6 @@ namespace Hopac.Core {
     }
     internal override void DoWork(ref Worker wr) {
       var pk = this.pk;
-      if (null == pk)
-        goto DoCont;
       var cts = this.cts;
       if (null == cts)
         goto Done;
@@ -296,7 +291,6 @@ namespace Hopac.Core {
       cts.Dispose();
       if (0 != picked)
         goto Done;
-    DoCont:
       if (TaskStatus.RanToCompletion == uT.Status)
         uK.DoWork(ref wr);
       else

--- a/Libs/Hopac.Core/External/Tasks.cs
+++ b/Libs/Hopac.Core/External/Tasks.cs
@@ -4,6 +4,7 @@ namespace Hopac.Core {
   using Microsoft.FSharp.Core;
   using System;
   using System.Runtime.CompilerServices;
+  using System.Threading;
   using System.Threading.Tasks;
 
   ///
@@ -91,11 +92,10 @@ namespace Hopac.Core {
   }
 
   ///
-  public sealed class AwaitTaskWithResult<X> : Job<X> {
-    private Task<X> xT;
+  public abstract class TaskWithResultToJob<X> : Job<X> {
     ///
-    [MethodImpl(AggressiveInlining.Flag)]
-    public AwaitTaskWithResult(Task<X> xT) { this.xT = xT; }
+    public abstract Task<X> Start();
+    ///
     private sealed class State : Work {
       private Task<X> xT;
       private Cont<X> xK;
@@ -120,7 +120,7 @@ namespace Hopac.Core {
       }
     }
     internal override void DoJob(ref Worker wr, Cont<X> xK) {
-      var xT = this.xT;
+      var xT = this.Start();
       if (TaskStatus.RanToCompletion == xT.Status)
         Cont.Do(xK, ref wr, xT.Result);
       else
@@ -129,11 +129,10 @@ namespace Hopac.Core {
   }
 
   ///
-  public sealed class AwaitTask : Job<Unit> {
-    private Task uT;
+  public abstract class TaskToJob : Job<Unit> {
     ///
-    [MethodImpl(AggressiveInlining.Flag)]
-    public AwaitTask(Task uT) { this.uT = uT; }
+    public abstract Task Start();
+    ///
     private sealed class State : Work {
       private Task uT;
       private Cont<Unit> uK;
@@ -162,11 +161,107 @@ namespace Hopac.Core {
       }
     }
     internal override void DoJob(ref Worker wr, Cont<Unit> uK) {
-      var uT = this.uT;
+      var uT = this.Start();
       if (TaskStatus.RanToCompletion == uT.Status)
         Work.Do(uK, ref wr);
       else
         uT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new State(uT, uK, wr.Scheduler).Ready);
+    }
+  }
+
+  ///
+  public abstract class TaskWithResultToAlt<X> : Alt<X> {
+    ///
+    public abstract Task<X> Start(CancellationToken t);
+    private sealed class State : Cont<Unit> {
+      private CancellationTokenSource cts;
+      private Pick pk;
+      private int me;
+      private Task<X> xT;
+      private Cont<X> xK;
+      private Scheduler sr;
+      [MethodImpl(AggressiveInlining.Flag)]
+      public State(CancellationTokenSource cts, Pick pk, int me, Task<X> xT, Cont<X> xK, Scheduler sr) {
+        this.cts = cts;
+        this.pk = pk;
+        this.me = me;
+        this.xT = xT;
+        this.xK = xK;
+        this.sr = sr;
+      }
+      [MethodImpl(AggressiveInlining.Flag)]
+      public State(Task<X> xT, Cont<X> xK, Scheduler sr) {
+        this.xT = xT;
+        this.xK = xK;
+        this.sr = sr;
+      }
+      internal override Proc GetProc(ref Worker wr) {
+        return xK.GetProc(ref wr);
+      }
+      internal override void DoHandle(ref Worker wr, Exception e) {
+        xK.DoHandle(ref wr, e);
+      }
+      internal override void DoWork(ref Worker wr) {
+        var pk = this.pk;
+        if (null == pk)
+          goto DoCont;
+        var cts = this.cts;
+        if (null == cts)
+          goto Done;
+        this.cts = null;
+        var picked = Pick.PickAndSetNacks(pk, ref wr, this.me);
+        if (0 != picked)
+          cts.Cancel();
+        cts.Dispose();
+        if (0 != picked)
+          goto Done;
+      DoCont:
+        xK.DoCont(ref wr, xT.Result);
+      Done:
+        return;
+      }
+      internal override void DoCont(ref Worker wr, Unit value) {
+        this.DoWork(ref wr);
+      }
+      public void Ready() {
+        Worker.RunOnThisThread(this.sr, this);
+      }
+    }
+    internal override void DoJob(ref Worker wr, Cont<X> xK) {
+      var xT = Start(new CancellationToken(false));
+      if (TaskStatus.RanToCompletion == xT.Status)
+        Cont.Do(xK, ref wr, xT.Result);
+      else
+        xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(new State(xT, xK, wr.Scheduler).Ready);
+    }
+    internal override void TryAlt(ref Worker wr, int i, Cont<X> xK, Else xE) {
+      var pk = xE.pk;
+      var nk = Pick.ClaimAndAddNack(pk, i);
+      if (null != nk) {
+        var cts = new CancellationTokenSource();
+        Task<X> xT;
+        try {
+          xT = this.Start(cts.Token);
+        } catch (Exception e) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          cts.Dispose();
+          Handler.DoHandle(xK, ref wr, e);
+          return;
+        }
+        if (TaskStatus.RanToCompletion == xT.Status) {
+          Pick.PickClaimedAndSetNacks(ref wr, i, pk);
+          cts.Dispose();
+          Cont.Do(xK, ref wr, xT.Result);
+        } else {
+          var state = new State(cts, pk, i, xT, xK, wr.Scheduler);
+          nk.UnsafeAddReader(state);
+          Pick.Unclaim(pk);
+          var j = i + 1;
+          nk.I1 = j;
+          xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(state.Ready);
+          xE.TryElse(ref wr, j);
+        }
+      }
     }
   }
 }

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -622,6 +622,13 @@ module Alt =
       override xA'.DoJob (wr, xK) = xA.DoJob (&wr, xK)
       override xA'.TryAlt (wr, i, xK, xE) = xA.TryAlt (&wr, i, xK, xE)}
 
+  let inline fromCancellableTask (t2xT: CancellationToken -> Task<'x>) =
+    {new TaskToAlt<_> () with
+      override xA'.Start t = t2xT t} :> Alt<_>
+  let inline fromCancellableUnitTask (t2uT: CancellationToken -> Task) =
+    {new TaskToAlt () with
+      override xA'.Start t = t2uT t} :> Alt<_>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 module Scheduler =
@@ -1384,6 +1391,23 @@ module Job =
       override xJ'.DoBegin (acb, s) = doBegin (acb, s)
       override xJ'.DoEnd (iar) = doEnd iar} :> Job<_>
 
+  let inline byStartingTask (u2xT: unit -> Task<'x>) =
+    {new TaskToJob<_> () with
+      override xJ'.Start () = u2xT ()} :> Job<'x>
+  let inline byStartingUnitTask (u2uT: unit -> Task) =
+    {new TaskToJob () with
+      override xJ'.Start () = u2uT ()} :> Job<unit>
+
+  let inline awaitTask (xT: Task<'x>) = byStartingTask (fun () -> xT)
+  let inline awaitUnitTask (uT: Task) = byStartingUnitTask (fun () -> uT)
+
+  let inline bindTask (x2yJ: 'x -> #Job<'y>) (xT: Task<'x>) =
+    {new BindTask<'x, 'y> () with
+      override yJ'.Do (x) = upcast x2yJ x}.InternalInit(xT)
+  let inline bindUnitTask (u2xJ: unit -> #Job<'x>) (uT: Task) =
+    {new BindTask<'x> () with
+      override xJ'.Do () = upcast u2xJ ()}.InternalInit(uT)
+
   //////////////////////////////////////////////////////////////////////////////
 
   module Scheduler =
@@ -1789,30 +1813,14 @@ module Extensions =
   //////////////////////////////////////////////////////////////////////////////
 
   type Task with
-    static member inline toAlt (t2xT: CancellationToken -> Task<'x>) =
-      {new TaskWithResultToAlt<_> () with
-        override xA'.Start t = t2xT t} :> Alt<_>
-
-//    static member toAlt (t2uT: CancellationToken -> Task) : Alt<unit> =
-//      failwith "XXX"
-
-    static member inline toJob (u2xT: unit -> Task<'x>) =
-      {new TaskWithResultToJob<_> () with
-        override xJ'.Start () = u2xT ()} :> Job<'x>
-    static member inline toJob (u2uT: unit -> Task) =
-      {new TaskToJob () with
-        override xJ'.Start () = u2uT ()} :> Job<unit>
-
-    static member inline awaitJob (xT: Task<'x>) = Task.toJob (fun () -> xT)
-    static member inline awaitJob (uT: Task) = Task.toJob (fun () -> uT)
-
-    static member inline bindJob (xT: Task<'x>, x2yJ: 'x -> #Job<'y>) =
-      {new BindTaskWithResult<'x, 'y> () with
-        override yJ'.Do (x) = upcast x2yJ x}.InternalInit(xT)
-
-    static member inline bindJob (uT: Task, u2xJ: unit -> #Job<'x>) =
-      {new BindTask<'x> () with
-        override xJ'.Do () = upcast u2xJ ()}.InternalInit(uT)
+    [<Obsolete "Use `Job.awaitTask`">]
+    static member inline awaitJob (xT: Task<'x>) = Job.awaitTask xT
+    [<Obsolete "Use `Job.awaitUnitTask`">]
+    static member inline awaitJob (uT: Task) = Job.awaitUnitTask uT
+    [<Obsolete "Use `Job.bindTask`">]
+    static member inline bindJob (xT: Task<'x>, x2yJ: 'x -> #Job<'y>) = Job.bindTask x2yJ xT
+    [<Obsolete "Use `Job.bindUnitTask`">]
+    static member inline bindJob (uT: Task, u2xJ: unit -> #Job<'x>) = Job.bindUnitTask u2xJ uT
 
     static member startJob (xJ: Job<'x>) =
       {new Job<Task<'x>> () with
@@ -2079,9 +2087,10 @@ type JobBuilder () =
   member inline __.Bind (xA: Async<'x>, x2yJ: 'x -> Job<'y>) : Job<'y> =
     Async.toJob xA >>= x2yJ
   member inline __.Bind (xT: Task<'x>, x2yJ: 'x -> Job<'y>) : Job<'y> =
-    Task.bindJob (xT, x2yJ)
+    Job.bindTask x2yJ xT
+  [<Obsolete "The non-generic Task Bind overload will be removed, use `Job.awaitUnitTask`.">]
   member inline __.Bind (uT: Task, u2xJ: unit -> Job<'x>) : Job<'x> =
-    Task.bindJob (uT, u2xJ)
+    Job.bindUnitTask u2xJ uT
   member inline __.Bind (xJ: Job<'x>, x2yJ: 'x -> Job<'y>) : Job<'y> =
     xJ >>= x2yJ
   member inline __.Combine (uJ: Job<unit>, xJ: Job<'x>) : Job<'x> = uJ >>=. xJ
@@ -2091,8 +2100,9 @@ type JobBuilder () =
   member inline __.Return (x: 'x) : Job<'x> = Job.result x
   member inline __.ReturnFrom (xO: IObservable<'x>) = xO.onceAlt :> Job<_>
   member inline __.ReturnFrom (xA: Async<'x>) : Job<'x> = Async.toJob xA
-  member inline __.ReturnFrom (xT: Task<'x>) : Job<'x> = Task.awaitJob xT
-  member inline __.ReturnFrom (uT: Task) : Job<unit> = Task.awaitJob uT
+  member inline __.ReturnFrom (xT: Task<'x>) : Job<'x> = Job.awaitTask xT
+  [<Obsolete "The non-generic Task ReturnFrom overload will be removed, use `Job.awaitUnitTask`.">]
+  member inline __.ReturnFrom (uT: Task) : Job<unit> = Job.awaitUnitTask uT
   member inline __.ReturnFrom (xJ: Job<'x>) : Job<'x> = xJ
   member inline __.TryFinally (xJ: Job<'x>, u2u: unit -> unit) : Job<'x> =
     Job.tryFinallyFun xJ u2u

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1387,9 +1387,7 @@ module Job =
 
   let inline fromEndBegin (doEnd: IAsyncResult -> 'x)
                           (doBegin: AsyncCallback * obj -> IAsyncResult) =
-    {new JobFromBeginEnd<'x> () with
-      override xJ'.DoBegin (acb, s) = doBegin (acb, s)
-      override xJ'.DoEnd (iar) = doEnd iar} :> Job<_>
+    fromBeginEnd doBegin doEnd
 
   let inline byStartingTask (u2xT: unit -> Task<'x>) =
     {new TaskToJob<_> () with

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -2092,6 +2092,12 @@ module Extensions =
   /// comonadic while jobs are monadic.
 #endif
   type Task with
+    static member inline toAlt: (CancellationToken -> Task<'x>) -> Alt<'x>
+//    static member inline toAlt: (CancellationToken -> Task)     -> Alt<unit>
+
+    static member inline toJob: (unit              -> Task<'x>) -> Job<'x>
+    static member inline toJob: (unit              -> Task)     -> Job<unit>
+
     /// Creates a job that waits for the given task to finish and then returns
     /// the result of the task.  Note that this does not start the task.  Make
     /// sure that the task is started correctly.

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -734,6 +734,38 @@ module Job =
   /// doEnd`.
   val inline fromEndBegin: (IAsyncResult -> 'x) -> (AsyncCallback * obj -> IAsyncResult) -> Job<'x>
 
+  val inline byStartingTask:     (unit -> Task<'x>) -> Job<'x>
+  val inline byStartingUnitTask: (unit -> Task)     -> Job<unit>
+
+  /// Creates a job that waits for the given task to finish and then returns the
+  /// result of the task.  Note that this does not start the task.  Make sure
+  /// that the task is started correctly.
+#if DOC
+  ///
+  /// Reference implementation:
+  ///
+  ///> let awaitTask (xT: Task<'x>) =
+  ///>   Job.Scheduler.bind <| fun sr ->
+  ///>   let xI = IVar ()
+  ///>   xT.ContinueWith (Action<Threading.Tasks.Task>(fun _ ->
+  ///>     Scheduler.start sr (try xI *<= xT.Result with e -> xI *<=! e)))
+  ///>   |> ignore
+  ///>   xI
+#endif
+  val inline awaitTask:     Task<'x> -> Job<'x>
+
+  /// Creates a job that waits until the given task finishes.  Note that this
+  /// does not start the task.  Make sure that the task is started correctly.
+  val inline awaitUnitTask: Task     -> Job<unit>
+
+  /// `bindTask x2yJ xT` is equivalent to `awaitTask xT >>= x2yJ`.
+  val inline bindTask:     ('x   -> #Job<'y>) -> Task<'x> -> Job<'y>
+
+  /// `bindUnitTask u2xJ uT` is equivalent to `awaitTask uT >>= u2xJ`.
+  val inline bindUnitTask: (unit -> #Job<'y>) -> Task     -> Job<'y>
+
+  //////////////////////////////////////////////////////////////////////////////
+
   //# Debugging
 
   /// Given a job, creates a new job that behaves exactly like the given job,
@@ -788,7 +820,7 @@ module Job =
     ///
     /// There are other similar examples as reference implementations of various
     /// Hopac primitives.  See, for example, the reference implementations of
-    /// `fromBeginEnd` and `Task.awaitJob`.
+    /// `fromBeginEnd` and `Job.awaitTask`.
 
 #endif
     val inline bind: (Scheduler -> #Job<'x>) -> Job<'x>
@@ -1186,6 +1218,11 @@ module Alt =
   ///>    <| Job.thunk u2u
 #endif
   val tryFinallyFun: Alt<'x> -> (unit -> unit) -> Alt<'x>
+
+  //# Interop
+
+  val inline fromCancellableTask:     (CancellationToken -> Task<'x>) -> Alt<'x>
+  val inline fromCancellableUnitTask: (CancellationToken -> Task)     -> Alt<unit>
 
   //# Debugging
 
@@ -2092,37 +2129,13 @@ module Extensions =
   /// comonadic while jobs are monadic.
 #endif
   type Task with
-    static member inline toAlt: (CancellationToken -> Task<'x>) -> Alt<'x>
-//    static member inline toAlt: (CancellationToken -> Task)     -> Alt<unit>
-
-    static member inline toJob: (unit              -> Task<'x>) -> Job<'x>
-    static member inline toJob: (unit              -> Task)     -> Job<unit>
-
-    /// Creates a job that waits for the given task to finish and then returns
-    /// the result of the task.  Note that this does not start the task.  Make
-    /// sure that the task is started correctly.
-#if DOC
-    ///
-    /// Reference implementation:
-    ///
-    ///> let awaitJob (xT: Task<'x>) =
-    ///>   Job.Scheduler.bind <| fun sr ->
-    ///>   let xI = IVar ()
-    ///>   xT.ContinueWith (Action<Threading.Tasks.Task>(fun _ ->
-    ///>     Scheduler.start sr (try xI *<= xT.Result with e -> xI *<=! e)))
-    ///>   |> ignore
-    ///>   xI
-#endif
+    [<Obsolete "Use `Job.awaitTask`">]
     static member inline awaitJob: Task<'x> -> Job<'x>
-
-    /// Creates a job that waits until the given task finishes.  Note that this
-    /// does not start the task.  Make sure that the task is started correctly.
+    [<Obsolete "Use `Job.awaitUnitTask`">]
     static member inline awaitJob: Task -> Job<unit>
-
-    /// `bindJob (xT, x2yJ)` is equivalent to `awaitJob xT >>= x2yJ`.
+    [<Obsolete "Use `Job.bindTask`">]
     static member inline bindJob: Task<'x> * ('x   -> #Job<'y>) -> Job<'y>
-
-    /// `bindJob (uT, u2xJ)` is equivalent to `awaitJob uT >>= u2xJ`.
+    [<Obsolete "Use `Job.bindUnitTask`">]
     static member inline bindJob: Task     * (unit -> #Job<'x>) -> Job<'x>
 
     /// Creates a job that starts the given job as a separate concurrent job,

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -766,8 +766,6 @@ module Job =
   /// `bindUnitTask u2xJ uT` is equivalent to `awaitTask uT >>= u2xJ`.
   val inline bindUnitTask: (unit -> #Job<'y>) -> Task     -> Job<'y>
 
-  //////////////////////////////////////////////////////////////////////////////
-
   //# Debugging
 
   /// Given a job, creates a new job that behaves exactly like the given job,

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -734,6 +734,8 @@ module Job =
   /// doEnd`.
   val inline fromEndBegin: (IAsyncResult -> 'x) -> (AsyncCallback * obj -> IAsyncResult) -> Job<'x>
 
+  val inline fromAsync: Async<'x> -> Job<'x>
+
   val inline byStartingTask:     (unit -> Task<'x>) -> Job<'x>
   val inline byStartingUnitTask: (unit -> Task)     -> Job<unit>
 
@@ -1220,6 +1222,13 @@ module Alt =
   val tryFinallyFun: Alt<'x> -> (unit -> unit) -> Alt<'x>
 
   //# Interop
+
+  val inline fromBeginEndCancel: (AsyncCallback * obj -> IAsyncResult)
+                       -> (IAsyncResult -> 'x)
+                       -> (IAsyncResult -> unit)
+                       -> Alt<'x>
+
+  val inline fromAsync: Async<'x> -> Alt<'x>
 
   val inline fromCancellableTask:     (CancellationToken -> Task<'x>) -> Alt<'x>
   val inline fromCancellableUnitTask: (CancellationToken -> Task)     -> Alt<unit>
@@ -2010,6 +2019,7 @@ module Extensions =
     /// thread or synchronization context switching async operation in your
     /// async operation.
 #endif
+    [<Obsolete "`Async.toJob` has been deprecated. Use `Job.fromAsync` and switch synchronization context explicitly if necessary.">]
     val toJob: Async<'x> -> Job<'x>
 
     /// Creates a job that posts the given async operation to the specified
@@ -2030,6 +2040,7 @@ module Extensions =
     /// thread or synchronization context switching async operation in your
     /// async operation.
 #endif
+    [<Obsolete "`Async.toAlt` has been deprecated. Use `Alt.fromAsync` and switch synchronization context explicitly if necessary.">]
     val toAlt: Async<'x> -> Alt<'x>
 
     /// Creates an alternative that, when instantiated, posts the given async

--- a/Tests/AdHocTests/AdHocTests.fsproj
+++ b/Tests/AdHocTests/AdHocTests.fsproj
@@ -60,6 +60,8 @@
   <ItemGroup>
     <None Include="App.config" />
     <Compile Include="Util.fs" />
+    <Compile Include="RunTask.fsi" />
+    <Compile Include="RunTask.fs" />
     <Compile Include="JobTests.fs" />
     <Compile Include="TaskTests.fs" />
     <Compile Include="BuilderTests.fs" />

--- a/Tests/AdHocTests/AdHocTests.fsproj
+++ b/Tests/AdHocTests/AdHocTests.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -61,6 +61,7 @@
     <None Include="App.config" />
     <Compile Include="Util.fs" />
     <Compile Include="JobTests.fs" />
+    <Compile Include="TaskTests.fs" />
     <Compile Include="BuilderTests.fs" />
     <Compile Include="StreamTests.fs" />
     <Compile Include="Main.fs" />

--- a/Tests/AdHocTests/Main.fs
+++ b/Tests/AdHocTests/Main.fs
@@ -5,5 +5,6 @@ module Main
 [<EntryPoint>]
 let main _ =
   JobTests.run ()
+  TaskTests.run ()
   StreamTests.run ()
   exitCode

--- a/Tests/AdHocTests/RunTask.fs
+++ b/Tests/AdHocTests/RunTask.fs
@@ -1,0 +1,143 @@
+// Copyright (C) by Vesa Karvonen
+
+module RunTask
+
+open System
+open System.Threading.Tasks
+
+let inline (^) x = x
+let inline tryAp x2y x yK eK =
+  let mutable e = null
+  let y = try x2y x with e' -> e <- e' ; Unchecked.defaultof<_>
+  match e with
+   | null -> yK y
+   | e -> eK e
+let inline tryIn u2x xK eK = tryAp u2x () xK eK
+let inline onCompleted xT2u (xT: #Task) =
+  xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(fun () -> xT2u xT)
+let inline setTcs (tcs: TaskCompletionSource<_>) (xT: Task<_>) =
+  match xT.Status with
+   | TaskStatus.Canceled -> tcs.SetCanceled ()
+   | TaskStatus.Faulted  -> tcs.SetException xT.Exception
+   | _                   -> tcs.SetResult xT.Result
+let inline withTcs tcs2u =
+  let tcs = TaskCompletionSource ()
+  tcs2u tcs
+  tcs.Task
+let stop = Task.FromResult () :> Task
+
+let inline result x = Task.FromResult x
+let zero = result ()
+let inline bind (x2yT: _ -> Task<_>) (xT: Task<_>) = withTcs <| fun tcs ->
+  xT
+  |> onCompleted ^ fun xT ->
+       tryIn <| fun () -> x2yT xT.Result
+        <| onCompleted ^ setTcs tcs
+        <| fun e ->
+             if xT.Status = TaskStatus.Canceled
+             then tcs.SetCanceled ()
+             else tcs.SetException e
+let inline bindTask (u2xT: _ -> Task<_>) (uT: Task) = withTcs <| fun tcs ->
+  uT
+  |> onCompleted ^ fun uT ->
+       match uT.Status with
+        | TaskStatus.Canceled -> tcs.SetCanceled ()
+        | TaskStatus.Faulted  -> tcs.SetException uT.Exception
+        | _ ->
+          tryIn u2xT
+           <| onCompleted ^ setTcs tcs
+           <| tcs.SetException
+let inline fromTask (uT: Task) =
+  match uT with
+   | :? Task<unit> as uT -> uT
+   | _ -> withTcs <| fun tcs ->
+     uT
+     |> onCompleted ^ fun uT ->
+          match uT.Status with
+           | TaskStatus.Canceled -> tcs.SetCanceled ()
+           | TaskStatus.Faulted  -> tcs.SetException uT.Exception
+           | _                   -> tcs.SetResult ()
+let inline whileDo (u2b: _ -> bool) (u2uT: _ -> #Task) = withTcs <| fun tcs ->
+  let rec loop () =
+    tryIn <| fun () -> if u2b () then u2uT () :> Task else stop
+     <| fun uT ->
+          if LanguagePrimitives.PhysicalEquality uT stop
+          then tcs.SetResult ()
+          else uT
+               |> onCompleted ^ fun uT ->
+                    match uT.Status with
+                     | TaskStatus.Canceled -> tcs.SetCanceled ()
+                     | TaskStatus.Faulted  -> tcs.SetException uT.Exception
+                     | _                   -> loop ()
+     <| tcs.SetException
+  loop ()
+let inline iterTask (x2uT: _ -> #Task) (xs: seq<_>) = withTcs <| fun tcs ->
+  tryIn xs.GetEnumerator
+   <| fun xs ->
+        let inline disposeAnd ef x = xs.Dispose () ; ef x
+        let rec loop () =
+          tryIn <| fun () -> if xs.MoveNext ()
+                             then x2uT xs.Current :> Task
+                             else stop
+           <| fun uT ->
+                if LanguagePrimitives.PhysicalEquality uT stop
+                then disposeAnd tcs.SetResult ()
+                else uT
+                     |> onCompleted ^ fun uT ->
+                          match uT.Status with
+                           | TaskStatus.Canceled ->
+                             disposeAnd tcs.SetCanceled ()
+                           | TaskStatus.Faulted ->
+                             uT.Exception |> disposeAnd tcs.SetException
+                           | _ ->
+                             loop ()
+           <| disposeAnd tcs.SetException
+        loop ()
+   <| tcs.SetException
+let inline tryFinally u2u (u2xT: _ -> Task<_>) = withTcs <| fun tcs ->
+  tryIn u2xT
+   <| onCompleted ^ fun xT ->
+        tryIn u2u
+         <| fun () -> setTcs tcs xT
+         <| tcs.SetException
+   <| tcs.SetException
+let inline tryWith (e2xT: _ -> Task<_>) (u2xT: _ -> Task<_>) = withTcs <| fun tcs ->
+  tryIn u2xT
+   <| onCompleted ^ fun xT ->
+        let s = xT.Status
+        if s = TaskStatus.RanToCompletion
+        then tcs.SetResult xT.Result
+        else tryAp e2xT <| if s = TaskStatus.Canceled
+                           then TaskCanceledException (xT) :> exn
+                           else xT.Exception :> exn
+              <| onCompleted ^ setTcs tcs
+              <| tcs.SetException
+   <| tcs.SetException
+let inline using (x2yT: _ -> Task<_>) (x: #IDisposable) = withTcs <| fun tcs ->
+  tryAp x2yT x
+   <| onCompleted ^ fun yT ->
+        tryIn x.Dispose
+         <| fun () -> setTcs tcs yT
+         <| tcs.SetException
+   <| fun e ->
+        tryIn x.Dispose
+         <| fun () -> tcs.SetException e
+         <| tcs.SetException
+
+type RunTaskBuilder () =
+  member __.Bind (uT, u2xT) = bindTask u2xT uT
+  member __.Bind (xT, x2yT) = bind x2yT xT
+  member __.Combine (uT, u2xT) = bindTask u2xT uT
+  member __.Delay (u2xT: unit -> Task<_>) = u2xT
+  member __.For (xs, x2uT) = iterTask x2uT xs
+  member __.Return x = result x
+  member __.ReturnFrom (xT: Task<_>) = xT
+  member __.ReturnFrom uT = fromTask uT
+  member __.Run (u2xT: _ -> Task<_>) = u2xT ()
+  member __.TryFinally (u2xT, u2u) = tryFinally u2u u2xT
+  member __.TryWith (u2xT, e2xT) = tryWith e2xT u2xT
+  member __.Using (x, x2yT) = using x2yT x
+  member __.While (u2b, u2uT) = whileDo u2b u2uT
+  member __.Zero () = zero
+
+let runTask = RunTaskBuilder ()

--- a/Tests/AdHocTests/RunTask.fs
+++ b/Tests/AdHocTests/RunTask.fs
@@ -3,7 +3,12 @@
 module RunTask
 
 open System
+open System.Runtime.CompilerServices
 open System.Threading.Tasks
+
+type Stop () = class end
+let stop = Task.FromResult (Stop ()) :> Task
+let zero = Task.FromResult ()
 
 let inline (^) x = x
 let inline tryAp x2y x yK eK =
@@ -13,131 +18,114 @@ let inline tryAp x2y x yK eK =
    | null -> yK y
    | e -> eK e
 let inline tryIn u2x xK eK = tryAp u2x () xK eK
-let inline onCompleted xT2u (xT: #Task) =
-  xT.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(fun () -> xT2u xT)
-let inline setTcs (tcs: TaskCompletionSource<_>) (xT: Task<_>) =
-  match xT.Status with
-   | TaskStatus.Canceled -> tcs.SetCanceled ()
-   | TaskStatus.Faulted  -> tcs.SetException xT.Exception
-   | _                   -> tcs.SetResult xT.Result
 let inline withTcs tcs2u =
   let tcs = TaskCompletionSource ()
   tcs2u tcs
   tcs.Task
-let stop = Task.FromResult () :> Task
-
-let inline result x = Task.FromResult x
-let zero = result ()
-let inline bind (x2yT: _ -> Task<_>) (xT: Task<_>) = withTcs <| fun tcs ->
-  xT
-  |> onCompleted ^ fun xT ->
-       tryIn <| fun () -> x2yT xT.Result
-        <| onCompleted ^ setTcs tcs
-        <| fun e ->
-             if xT.Status = TaskStatus.Canceled
-             then tcs.SetCanceled ()
-             else tcs.SetException e
-let inline bindTask (u2xT: _ -> Task<_>) (uT: Task) = withTcs <| fun tcs ->
-  uT
-  |> onCompleted ^ fun uT ->
-       match uT.Status with
-        | TaskStatus.Canceled -> tcs.SetCanceled ()
-        | TaskStatus.Faulted  -> tcs.SetException uT.Exception
-        | _ ->
-          tryIn u2xT
-           <| onCompleted ^ setTcs tcs
-           <| tcs.SetException
-let inline fromTask (uT: Task) =
-  match uT with
-   | :? Task<unit> as uT -> uT
-   | _ -> withTcs <| fun tcs ->
-     uT
-     |> onCompleted ^ fun uT ->
-          match uT.Status with
-           | TaskStatus.Canceled -> tcs.SetCanceled ()
-           | TaskStatus.Faulted  -> tcs.SetException uT.Exception
-           | _                   -> tcs.SetResult ()
-let inline whileDo (u2b: _ -> bool) (u2uT: _ -> #Task) = withTcs <| fun tcs ->
-  let rec loop () =
-    tryIn <| fun () -> if u2b () then u2uT () :> Task else stop
-     <| fun uT ->
-          if LanguagePrimitives.PhysicalEquality uT stop
-          then tcs.SetResult ()
-          else uT
-               |> onCompleted ^ fun uT ->
-                    match uT.Status with
-                     | TaskStatus.Canceled -> tcs.SetCanceled ()
-                     | TaskStatus.Faulted  -> tcs.SetException uT.Exception
-                     | _                   -> loop ()
-     <| tcs.SetException
-  loop ()
-let inline iterTask (x2uT: _ -> #Task) (xs: seq<_>) = withTcs <| fun tcs ->
-  tryIn xs.GetEnumerator
-   <| fun xs ->
-        let inline disposeAnd ef x = xs.Dispose () ; ef x
-        let rec loop () =
-          tryIn <| fun () -> if xs.MoveNext ()
-                             then x2uT xs.Current :> Task
-                             else stop
-           <| fun uT ->
-                if LanguagePrimitives.PhysicalEquality uT stop
-                then disposeAnd tcs.SetResult ()
-                else uT
-                     |> onCompleted ^ fun uT ->
-                          match uT.Status with
-                           | TaskStatus.Canceled ->
-                             disposeAnd tcs.SetCanceled ()
-                           | TaskStatus.Faulted ->
-                             uT.Exception |> disposeAnd tcs.SetException
-                           | _ ->
-                             loop ()
-           <| disposeAnd tcs.SetException
-        loop ()
-   <| tcs.SetException
-let inline tryFinally u2u (u2xT: _ -> Task<_>) = withTcs <| fun tcs ->
-  tryIn u2xT
-   <| onCompleted ^ fun xT ->
-        tryIn u2u
-         <| fun () -> setTcs tcs xT
-         <| tcs.SetException
-   <| tcs.SetException
-let inline tryWith (e2xT: _ -> Task<_>) (u2xT: _ -> Task<_>) = withTcs <| fun tcs ->
-  tryIn u2xT
-   <| onCompleted ^ fun xT ->
-        let s = xT.Status
-        if s = TaskStatus.RanToCompletion
-        then tcs.SetResult xT.Result
-        else tryAp e2xT <| if s = TaskStatus.Canceled
-                           then TaskCanceledException (xT) :> exn
-                           else xT.Exception :> exn
-              <| onCompleted ^ setTcs tcs
-              <| tcs.SetException
-   <| tcs.SetException
-let inline using (x2yT: _ -> Task<_>) (x: #IDisposable) = withTcs <| fun tcs ->
-  tryAp x2yT x
-   <| onCompleted ^ fun yT ->
-        tryIn x.Dispose
-         <| fun () -> setTcs tcs yT
-         <| tcs.SetException
+let inline setRes (tcs: TaskCompletionSource<_>) = tcs.SetResult
+let inline setExn (tcs: TaskCompletionSource<_>) (e: exn) =
+  match e with
+   | :? TaskCanceledException -> tcs.SetCanceled ()
+   | e -> tcs.SetException e
+let inline bindTo tcs (xT: Task<_>) =
+  let xA = xT.GetAwaiter ()
+  xA.OnCompleted(fun () ->
+    tryIn xA.GetResult
+     <| setRes tcs
+     <| setExn tcs)
+let inline bracket (w2xT: _ -> Task<_>) u2u w = withTcs <| fun tcs ->
+  tryAp w2xT w
+   <| fun xT ->
+        let xA = xT.GetAwaiter ()
+        xA.OnCompleted(fun () ->
+          tryIn (u2u >> xA.GetResult) (setRes tcs) (setExn tcs))
    <| fun e ->
-        tryIn x.Dispose
-         <| fun () -> tcs.SetException e
-         <| tcs.SetException
+        tryIn u2u
+         <| fun () -> setExn tcs e
+         <| setExn tcs
 
 type RunTaskBuilder () =
-  member __.Bind (uT, u2xT) = bindTask u2xT uT
-  member __.Bind (xT, x2yT) = bind x2yT xT
-  member __.Combine (uT, u2xT) = bindTask u2xT uT
-  member __.Delay (u2xT: unit -> Task<_>) = u2xT
-  member __.For (xs, x2uT) = iterTask x2uT xs
-  member __.Return x = result x
+  member __.Bind (wT: Task, w2xT: _ -> Task<_>) = withTcs <| fun tcs ->
+    let wA = wT.GetAwaiter()
+    wA.OnCompleted(fun () ->
+      tryIn (wA.GetResult >> w2xT) (bindTo tcs) (setExn tcs))
+  member __.Bind (wT: Task<_>, w2xT: _ -> Task<_>) = withTcs <| fun tcs ->
+    let wA = wT.GetAwaiter ()
+    wA.OnCompleted(fun () ->
+      tryIn (wA.GetResult >> w2xT) (bindTo tcs) (setExn tcs))
+  member __.Bind (wT: ConfiguredTaskAwaitable, w2xT: _ -> Task<_>) =
+    withTcs <| fun tcs ->
+    let wA = wT.GetAwaiter ()
+    wA.OnCompleted(fun () ->
+      tryIn (wA.GetResult >> w2xT) (bindTo tcs) (setExn tcs))
+  member __.Bind (wT: ConfiguredTaskAwaitable<_>, w2xT: _ -> Task<_>) =
+    withTcs <| fun tcs ->
+    let wA = wT.GetAwaiter ()
+    wA.OnCompleted(fun () ->
+      tryIn (wA.GetResult >> w2xT) (bindTo tcs) (setExn tcs))
+  member __.Combine (wT: Task, w2xT) = __.Bind (wT, w2xT)
+  member __.Delay (w2xT: unit -> Task<_>) = w2xT
+  member __.For (vs: seq<_>, v2wT: _ -> #Task) = withTcs <| fun tcs ->
+    tryIn vs.GetEnumerator
+     <| fun vs ->
+          let inline disposeAnd ef x =
+            try vs.Dispose () ; ef tcs x
+            with e -> setExn tcs e
+          let rec loop () =
+            tryIn <| fun () -> if vs.MoveNext ()
+                               then v2wT vs.Current :> Task
+                               else stop
+             <| fun wT ->
+                  if LanguagePrimitives.PhysicalEquality wT stop
+                  then disposeAnd setRes ()
+                  else let wA = wT.GetAwaiter ()
+                       wA.OnCompleted(fun () ->
+                         tryIn wA.GetResult loop (disposeAnd setExn))
+             <| disposeAnd setExn
+          loop ()
+     <| setExn tcs
+  member __.Return x = Task.FromResult x
+  member __.ReturnFrom (xT: Task) =
+    match xT with
+     | :? Task<unit> as xT -> xT
+     | _ -> withTcs <| fun tcs ->
+       let xA = xT.GetAwaiter ()
+       xA.OnCompleted(fun () ->
+         tryIn xA.GetResult (setRes tcs) (setExn tcs))
   member __.ReturnFrom (xT: Task<_>) = xT
-  member __.ReturnFrom uT = fromTask uT
-  member __.Run (u2xT: _ -> Task<_>) = u2xT ()
-  member __.TryFinally (u2xT, u2u) = tryFinally u2u u2xT
-  member __.TryWith (u2xT, e2xT) = tryWith e2xT u2xT
-  member __.Using (x, x2yT) = using x2yT x
-  member __.While (u2b, u2uT) = whileDo u2b u2uT
+  member __.ReturnFrom (xT: ConfiguredTaskAwaitable) = withTcs <| fun tcs ->
+    let xA = xT.GetAwaiter ()
+    xA.OnCompleted(fun () ->
+      tryIn xA.GetResult (setRes tcs) (setExn tcs))
+  member __.ReturnFrom (xT: ConfiguredTaskAwaitable<_>) = withTcs <| fun tcs ->
+    let xA = xT.GetAwaiter ()
+    xA.OnCompleted(fun () ->
+      tryIn xA.GetResult (setRes tcs) (setExn tcs))
+  member __.Run (w2xT: _ -> Task<_>) = w2xT ()
+  member __.TryFinally (w2xT: _ -> Task<_>, u2u) =
+    bracket w2xT u2u ()
+  member __.TryWith (w2xT: _ -> Task<_>, e2xT: _ -> Task<_>) =
+    withTcs <| fun tcs ->
+    let e2u e = tryAp e2xT e (bindTo tcs) (setExn tcs)
+    tryIn w2xT
+     <| fun xT ->
+          let xA = xT.GetAwaiter ()
+          xA.OnCompleted(fun () ->
+            tryIn xA.GetResult (setRes tcs) e2u)
+     <| e2u
+  member __.Using (x: #IDisposable, x2yT: _ -> Task<_>) =
+    bracket x2yT x.Dispose x
+  member __.While (u2b, u2wT: _ -> #Task) = withTcs <| fun tcs ->
+    let rec loop () =
+      tryIn <| fun () -> if u2b () then u2wT () :> Task else stop
+       <| fun wT ->
+            if LanguagePrimitives.PhysicalEquality wT stop
+            then setRes tcs ()
+            else let wA = wT.GetAwaiter ()
+                 wA.OnCompleted(fun () ->
+                   tryIn wA.GetResult loop (setExn tcs))
+       <| setExn tcs
+    loop ()
   member __.Zero () = zero
 
 let runTask = RunTaskBuilder ()

--- a/Tests/AdHocTests/RunTask.fsi
+++ b/Tests/AdHocTests/RunTask.fsi
@@ -3,22 +3,27 @@
 module RunTask
 
 open System
+open System.Runtime.CompilerServices
 open System.Threading.Tasks
 
 type RunTaskBuilder =
   new: unit -> RunTaskBuilder
-  member Bind: Task * (unit -> Task<'x>) -> Task<'x>
-  member Bind: Task<'x> * ('x -> Task<'y>) -> Task<'y>
+  member Bind:                    Task     * (unit -> Task<'x>) -> Task<'x>
+  member Bind:                    Task<'w> * ('w   -> Task<'x>) -> Task<'x>
+  member Bind: ConfiguredTaskAwaitable     * (unit -> Task<'x>) -> Task<'x>
+  member Bind: ConfiguredTaskAwaitable<'w> * ('w   -> Task<'x>) -> Task<'x>
   member Combine: Task * (unit -> Task<'x>) -> Task<'x>
   member Delay: (unit -> Task<'x>) -> (unit -> Task<'x>)
   member For: seq<'x> * ('x -> #Task) -> Task<unit>
   member Return: 'x -> Task<'x>
-  member ReturnFrom: Task<'x> -> Task<'x>
-  member ReturnFrom: Task -> Task<unit>
+  member ReturnFrom:                    Task     -> Task<unit>
+  member ReturnFrom:                    Task<'x> -> Task<'x>
+  member ReturnFrom: ConfiguredTaskAwaitable     -> Task<unit>
+  member ReturnFrom: ConfiguredTaskAwaitable<'x> -> Task<'x>
   member Run: (unit -> Task<'x>) -> Task<'x>
   member TryFinally: (unit -> Task<'x>) * (unit -> unit) -> Task<'x>
   member TryWith: (unit -> Task<'x>) * (exn -> Task<'x>) -> Task<'x>
-  member Using: 'x * ('x -> Task<'y>) -> Task<'y> when 'x :> IDisposable
+  member Using: 'w * ('w -> Task<'x>) -> Task<'x> when 'w :> IDisposable
   member While: (unit -> bool) * (unit -> #Task) -> Task<unit>
   member Zero: unit -> Task<unit>
 

--- a/Tests/AdHocTests/RunTask.fsi
+++ b/Tests/AdHocTests/RunTask.fsi
@@ -1,0 +1,25 @@
+// Copyright (C) by Vesa Karvonen
+
+module RunTask
+
+open System
+open System.Threading.Tasks
+
+type RunTaskBuilder =
+  new: unit -> RunTaskBuilder
+  member Bind: Task * (unit -> Task<'x>) -> Task<'x>
+  member Bind: Task<'x> * ('x -> Task<'y>) -> Task<'y>
+  member Combine: Task * (unit -> Task<'x>) -> Task<'x>
+  member Delay: (unit -> Task<'x>) -> (unit -> Task<'x>)
+  member For: seq<'x> * ('x -> #Task) -> Task<unit>
+  member Return: 'x -> Task<'x>
+  member ReturnFrom: Task<'x> -> Task<'x>
+  member ReturnFrom: Task -> Task<unit>
+  member Run: (unit -> Task<'x>) -> Task<'x>
+  member TryFinally: (unit -> Task<'x>) * (unit -> unit) -> Task<'x>
+  member TryWith: (unit -> Task<'x>) * (exn -> Task<'x>) -> Task<'x>
+  member Using: 'x * ('x -> Task<'y>) -> Task<'y> when 'x :> IDisposable
+  member While: (unit -> bool) * (unit -> #Task) -> Task<unit>
+  member Zero: unit -> Task<unit>
+
+val runTask: RunTaskBuilder

--- a/Tests/AdHocTests/TaskTests.fs
+++ b/Tests/AdHocTests/TaskTests.fs
@@ -8,40 +8,45 @@ open Hopac.Extensions
 open System
 open System.Threading
 open System.Threading.Tasks
+open RunTask
 
 exception Ex
 
+let inline (^) x = x
+
 let verify n c = printfn "%s %s" (if c then "Ok" else "FAILURE") n
 
-let delayAndThen (ms: int) fn =
-  Task.toAlt <| fun ct ->
-  Task.Delay(ms, ct).ContinueWith(Func<_,_>(fn), ct)
+let delayAndSet (ms: int) r = Task.toAlt <| fun ct -> runTask {
+  do! Task.Delay (ms, ct)
+  return match Interlocked.CompareExchange (r, ms, 0) with
+          | 0 -> ms
+          | ms ->
+            printfn "Unexpected %d" ms
+            failwithf "Unexpected %d" ms
+}
 
-let delayAndSet r (ms: int) =
-  delayAndThen ms <| fun t ->
-  match Interlocked.CompareExchange(r, ms, 0) with
-   | 0 -> ms
-   | ms ->
-     printfn "Unexpected %d %A" ms t.IsCanceled
-     failwithf "Unexpected %d" ms
+let delayAndRaise (ms: int) ex = Task.toAlt <| fun ct -> runTask {
+  do! Task.Delay (ms, ct)
+  return raise ex
+}
 
 let run () =
   do let r = ref 0
-     (delayAndSet r 100 <|> delayAndSet r 50 |> run = 50 && !r = 50)
+     (delayAndSet 100 r <|> delayAndSet 50 r |> run = 50 && !r = 50)
      |> verify "Delays"
 
   do let r = ref 0
-     (delayAndSet r 50 <|> delayAndSet r 100 |> run = 50 && !r = 50)
+     (delayAndSet 50 r <|> delayAndSet 100 r |> run = 50 && !r = 50)
      |> verify "Delays"
 
-  do Job.tryIn (delayAndSet (ref 1) 50
-                <|> Task.toAlt (fun _ -> raise Ex ; Task.FromResult 1))
+  do Job.tryIn (delayAndSet 50 ^ ref 1
+            <|> Task.toAlt ^ fun _ -> raise Ex ; Task.FromResult 1)
          <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
          <| fun e -> printfn "OK %A" e ; Job.unit ()
      |> run
 
-  do Job.tryIn (delayAndThen 50 (fun _ -> raise Ex)
-                <|> delayAndSet (ref 1) 100)
+  do Job.tryIn (delayAndRaise 50 Ex
+            <|> delayAndSet 100 ^ ref 1)
          <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
          <| fun e -> printfn "OK %A" <| e.GetBaseException () ; Job.unit ()
      |> run

--- a/Tests/AdHocTests/TaskTests.fs
+++ b/Tests/AdHocTests/TaskTests.fs
@@ -39,14 +39,14 @@ let run () =
      (delayAndSet 50 r <|> delayAndSet 100 r |> run = 50 && !r = 50)
      |> verify "Delays"
 
-  do Job.tryIn (delayAndSet 50 ^ ref 1
+  do Job.tryIn (delayAndSet 150 ^ ref 1
             <|> Alt.fromCancellableTask ^ fun _ -> raise Ex ; Task.FromResult 1)
          <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
          <| fun e -> printfn "OK %A" e ; Job.unit ()
      |> run
 
   do Job.tryIn (delayAndRaise 50 Ex
-            <|> delayAndSet 100 ^ ref 1)
+            <|> delayAndSet 200 ^ ref 1)
          <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
          <| fun e -> printfn "OK %A" <| e.GetBaseException () ; Job.unit ()
      |> run

--- a/Tests/AdHocTests/TaskTests.fs
+++ b/Tests/AdHocTests/TaskTests.fs
@@ -1,0 +1,47 @@
+﻿// Copyright (C) by Vesa Karvonen
+
+module TaskTests
+
+open Hopac
+open Hopac.Infixes
+open Hopac.Extensions
+open System
+open System.Threading
+open System.Threading.Tasks
+
+exception Ex
+
+let verify n c = printfn "%s %s" (if c then "Ok" else "FAILURE") n
+
+let delayAndThen (ms: int) fn =
+  Task.toAlt <| fun ct ->
+  Task.Delay(ms, ct).ContinueWith(Func<_,_>(fn), ct)
+
+let delayAndSet r (ms: int) =
+  delayAndThen ms <| fun t ->
+  match Interlocked.CompareExchange(r, ms, 0) with
+   | 0 -> ms
+   | ms ->
+     printfn "Unexpected %d %A" ms t.IsCanceled
+     failwithf "Unexpected %d" ms
+
+let run () =
+  do let r = ref 0
+     (delayAndSet r 100 <|> delayAndSet r 50 |> run = 50 && !r = 50)
+     |> verify "Delays"
+
+  do let r = ref 0
+     (delayAndSet r 50 <|> delayAndSet r 100 |> run = 50 && !r = 50)
+     |> verify "Delays"
+
+  do Job.tryIn (delayAndSet (ref 1) 50
+                <|> Task.toAlt (fun _ -> raise Ex ; Task.FromResult 1))
+         <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
+         <| fun e -> printfn "OK %A" e ; Job.unit ()
+     |> run
+
+  do Job.tryIn (delayAndThen 50 (fun _ -> raise Ex)
+                <|> delayAndSet (ref 1) 100)
+         <| fun x -> printfn "Unexpected %A" x ; Job.unit ()
+         <| fun e -> printfn "OK %A" <| e.GetBaseException () ; Job.unit ()
+     |> run


### PR DESCRIPTION
Previously we (roughly) had functions like:

```fs
val awaitJob: Task<'x> -> Job<'x>
```

But there is a semantic mismatch: a `Task<'x>` represents something that is already running while a `Job<'x>` is something that can be run any number of times.

The idea is to add conversions with better matching semantics:

```fs
val byStartingTask: (unit -> Task<'x>) -> Job<'x>
```

And more interestingly:

```fs
val fromCancellableTask: (CancellationToken -> Task<'x>) -> Alt<'x>
```

The idea in both is that the given function is called each time the returned `Alt` or `Job` is executed *to create and start a new task*.  This way there is no semantic mismatch.  This way we can also wrap tasks with cancellation as `Alt`s.
