### PR TITLE
Add stack to deadlock warning (and fix typo)

### DIFF
--- a/Libs/Hopac.Core/Util/Condition.cs
+++ b/Libs/Hopac.Core/Util/Condition.cs
@@ -25,8 +25,10 @@ namespace Hopac.Core {
             if (!warned && Worker.IsWorkerThread) {
               warned = true;
               StaticData.writeLine(
-                "WARNNG: You are making a blocking call from within a Hopac " +
+                "WARNING: You are making a blocking call from within a Hopac " +
                 "worker thread, which means that your program may deadlock.");
+              StaticData.writeLine("First occurrence (there may be others):");
+              StaticData.writeLine(System.Environment.StackTrace);
             }
             Monitor.Wait(o);
           }


### PR DESCRIPTION
I've had several occasions now where I've lost time trying to find deadlocks in my code (in some cases, only to find out that it was actually in a library I was consuming!)

This does add a minimal performance and spam overhead, but given it a) only runs at most once and b) it's likely to be inexperienced users of the library who see the message most frequently I think it's worthwhile.