### PR TITLE
WIP: Add `idle` function for cooperative yielding of execution

### DIFF
--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1660,6 +1660,16 @@ module Timer =
     let timeOut (span: System.TimeSpan) = timeOutTicks span.Ticks
     [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
     let timeOutMillis (ms: int) = timeOutTicks (int64 ms * 10000L)
+    [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
+    let idle =
+      {new Alt<unit> () with
+        override uA'.DoJob (wr, uK) =
+          (initGlobalTimer ()).SynchronizedPushTimed
+            (WorkTimedUnitCont (Environment.TickCount, uK))
+        override uA'.TryAlt (wr, i, uK, uE) =
+          (initGlobalTimer ()).SynchronizedPushTimed
+            (WorkTimedUnitCont (Environment.TickCount, i, uE.pk, uK))
+          uE.TryElse (&wr, i+1)}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -1394,6 +1394,11 @@ module Timer =
     /// The idea is that the `gotTimeoutOrDoneOtherwise` is filled, using
     /// `IVar.tryFill` as soon as the timeout is no longer useful.  This allows
     /// the timer mechanism to release the memory held by the timeout.
+    ///
+    /// A timeout of zero is optimized to an alternative that is immediately
+    /// available, while a negative timeout results in an `Alt` that is never
+    /// available. See `idle` for an alternative that yields the thread of
+    /// execution to any ready work before becoming available.
 #endif
     [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
     val timeOut:       TimeSpan -> Alt<unit>
@@ -1402,6 +1407,21 @@ module Timer =
     /// <| float n`.
     [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
     val timeOutMillis: int      -> Alt<unit>
+
+    /// Creates an alternative that yields the thread of execution to any ready
+    /// work and then becomes available.
+#if DOC
+    ///
+    /// This is similar to `timeOutMillis 0` except that it yields the current
+    /// thread of execution to any other ready work before attempting to
+    /// become available.
+    ///
+    /// When executing multiple concurrent jobs that do not have natural points
+    /// where they yield execution, `idle` allows progress to be made by other
+    /// ready work.
+#endif
+    [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
+    val idle :                     Alt<unit>
 
 #if DOC
 /// Represents a promise to produce a result at some point in the future.

--- a/Libs/Hopac/TopLevel.fs
+++ b/Libs/Hopac/TopLevel.fs
@@ -30,6 +30,7 @@ module Hopac =
 
   let inline timeOut x = Timer.Global.timeOut x
   let inline timeOutMillis x = Timer.Global.timeOutMillis x
+  let idle = Timer.Global.idle
 
   let inline memo (xJ: Job<'x>) = Promise<'x> xJ
 

--- a/Libs/Hopac/TopLevel.fsi
+++ b/Libs/Hopac/TopLevel.fsi
@@ -183,12 +183,31 @@ module Hopac =
   /// The idea is that the `gotTimeoutOrDoneOtherwise` is filled, using
   /// `IVar.tryFill` as soon as the timeout is no longer useful.  This allows
   /// the timer mechanism to release the memory held by the timeout.
+  ///
+  /// A timeout of zero is optimized to an alternative that is immediately
+  /// available, while a negative timeout results in an `Alt` that is never
+  /// available. See `idle` for an alternative that yields the thread of
+  /// execution to any ready work before becoming available.
 #endif
   val inline timeOut:       TimeSpan -> Alt<unit>
 
   /// `timeOutMillis n` is equivalent to `timeOut << TimeSpan.FromMilliseconds
   /// <| float n`.
   val inline timeOutMillis: int      -> Alt<unit>
+
+  /// Creates an alternative that yields the thread of execution to any ready
+  /// work and then becomes available.
+#if DOC
+  ///
+  /// This is similar to `timeOutMillis 0` except that it yields the current
+  /// thread of execution to any other ready work before attempting to
+  /// become available.
+  ///
+  /// When executing multiple concurrent jobs that do not have natural points
+  /// where they yield execution, `idle` allows progress to be made by other
+  /// ready work.
+#endif
+  val idle :                           Alt<unit>
 
   //# Promises
 


### PR DESCRIPTION
As mentioned in #126 on fairness. Creates an `Alt<unit>` that will yield the current thread of execution and queue further execution on the global scheduler.

Thoughts:
* ~~If the current work queue is empty, resume immediately and do not suspend.~~