### PR TITLE
Clean queues when using alternatives.

### DIFF
--- a/Libs/Hopac.Core/Communication/Promise.cs
+++ b/Libs/Hopac.Core/Communication/Promise.cs
@@ -120,14 +120,18 @@ namespace Hopac {
 
     Delayed:
       var readers = this.Readers;
-      this.Readers = null;
+
+      var taker = new Taker<T>();
+      this.Readers = taker;
+      taker.Next = taker;
+      taker.Pick = aE.pk;
       this.State = Running;
+
+      taker.Me = i;
+      taker.Cont = aK;
 
       var fulfill = readers as Fulfill;
       fulfill.tP = this;
-      fulfill.reader = aK;
-      fulfill.me = i;
-      fulfill.pk = aE.pk;
 
       Worker.PushNew(ref wr, fulfill);
       aE.TryElse(ref wr, i + i);

--- a/Libs/Hopac.Core/Communication/Promise.cs
+++ b/Libs/Hopac.Core/Communication/Promise.cs
@@ -125,10 +125,9 @@ namespace Hopac {
       this.Readers = taker;
       taker.Next = taker;
       taker.Pick = aE.pk;
-      this.State = Running;
-
       taker.Me = i;
       taker.Cont = aK;
+      this.State = Running;
 
       var fulfill = readers as Fulfill;
       fulfill.tP = this;


### PR DESCRIPTION
This should fix the space leaks encountered in #139 and #107.