### PR TITLE
WIP: Fix handling of `Task<T>` thrown Exceptions

### DIFF
--- a/Libs/Hopac.Core/External/Tasks.cs
+++ b/Libs/Hopac.Core/External/Tasks.cs
@@ -108,7 +108,11 @@ namespace Hopac.Core {
       xK.DoHandle(ref wr, e);
     }
     internal override void DoWork(ref Worker wr) {
-      xK.DoCont(ref wr, xT.Result);
+      var xT = this.xT;
+      if (TaskStatus.RanToCompletion == xT.Status)
+        xK.DoCont(ref wr, xT.Result);
+      else
+        xK.DoHandle(ref wr, xT.Exception);
     }
     public void Ready() {
       Worker.ContinueOnThisThread(this.sr, this);


### PR DESCRIPTION
Calling `xK.DoCont(ref wr, xT.Result)` when the `xT.Result` ends up resolving to an exception causes the resulting exception to be wrapped in an aggregate exception. This is undesired behavior.