### PR TITLE
Fix handling of canceled (unit) tasks

### DIFF
--- a/Libs/Hopac.Core/External/Tasks.cs
+++ b/Libs/Hopac.Core/External/Tasks.cs
@@ -108,7 +108,11 @@ namespace Hopac.Core {
       xK.DoHandle(ref wr, e);
     }
     internal override void DoWork(ref Worker wr) {
-      xK.DoCont(ref wr, xT.Result);
+      var xT = this.xT;
+      if (TaskStatus.RanToCompletion == xT.Status)
+        xK.DoCont(ref wr, xT.Result);
+      else
+        xK.DoHandle(ref wr, xT.Exception);
     }
     public void Ready() {
       Worker.ContinueOnThisThread(this.sr, this);

--- a/Tests/AdHocTests/TaskTests.fs
+++ b/Tests/AdHocTests/TaskTests.fs
@@ -46,6 +46,32 @@ let run () =
      |> run
      |> testExpected [Ex]
 
+  let cancelled = TaskCanceledException()
+
+  let tcs = TaskCompletionSource<int>()
+  do Job.fromTask ^ fun () -> tcs.SetCanceled() ; tcs.Task
+     |> Job.catch
+     |> run
+     |> testExpected [cancelled]
+
+  let tcs = TaskCompletionSource<int>()
+  do Job.fromUnitTask ^ fun () -> tcs.SetCanceled() ; tcs.Task :> Task
+     |> Job.catch
+     |> run
+     |> testExpected [cancelled]
+
+  let tcs = TaskCompletionSource<int>()
+  do Job.fromTask ^ fun () -> tcs.SetException(Ex) ; tcs.Task
+     |> Job.catch
+     |> run
+     |> testExpected [Ex]
+
+  let tcs = TaskCompletionSource<int>()
+  do Job.fromUnitTask ^ fun () -> tcs.SetException(Ex) ; tcs.Task :> Task
+     |> Job.catch
+     |> run
+     |> testExpected [Ex]
+
   do delayAndRaise 50 Ex
      <|> delayAndSet 203 ^ ref 1
      |> Job.catch


### PR DESCRIPTION
When used with `fromUnitTask`, a canceled `Task` would result in a faulted job with `null` for the exception. However when a `Task<T>` is cancelled in `fromTask`, an exception would be thrown on `.Result`, which would be caught by the `Worker` and the job would become faulted with a `TaskCanceledException` inside of an `AggregateException`.

This patch unifies the behavior by unifying the behavior of the Task interop jobs so that a canceled task results in the job being faulted with a `TaskCanceledException` as in the latter case above.

Also added are some minor changes so that when a `Task` or `Task<T>` is faulted (as opposed to canceled), the exception is passed directly to the handler rather than being rethrown on the `.Result`/`.Wait()` call.

Added tests to ensure that cancellation and faulted tasks are handled as expected.

Supersedes #149 
