### PR TITLE
Add programming guide and docs links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[ [Reference](http://hopac.github.io/Hopac/Hopac.html) ]
+[ [Reference](http://hopac.github.io/Hopac/Hopac.html) ] [ [Guide](Docs/Programming.md) ] [ [Docs](Docs/) ]
 
 Hopac is a [Concurrent ML](http://cml.cs.uchicago.edu/) style concurrent
 programming library for F#.


### PR DESCRIPTION
Perhaps this is just me being unperceptive (wouldn't be the first time!), but I completely looked past the fact that there was a documentation folder the first few times I looked at Hopac, and it gave me the impression that the library wasn't very beginner-friendly. Now, having actually read some of the documentation files, that couldn't be further from the truth - they're really good!

I'd like to propose that a link to the main programming guide (and the documentation folder) be added to the README.md, alongside the link to the reference.