### PR TITLE
Minor .NET fixes

### DIFF
--- a/Libs/Hopac.Core/Engine/Scheduler.cs
+++ b/Libs/Hopac.Core/Engine/Scheduler.cs
@@ -183,6 +183,7 @@ namespace Hopac {
     }
   }
 
+  [Serializable]
   internal class KillException : Exception { }
 
   internal class AbortWork : Work {

--- a/Libs/Hopac.Core/Engine/Scheduler.cs
+++ b/Libs/Hopac.Core/Engine/Scheduler.cs
@@ -183,7 +183,6 @@ namespace Hopac {
     }
   }
 
-  [Serializable]
   internal class KillException : Exception { }
 
   internal class AbortWork : Work {

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1198,6 +1198,7 @@ module Job =
       | null -> ()
       | _ -> Worker.RunOnThisThread (sr, xK')
      Scheduler.start sr uJ
+     base.Finalize()
     override xK'.GetProc (wr) =
      match xK'.Proc with
       | null ->


### PR DESCRIPTION
- KillException should be marked as Serializable [*](https://msdn.microsoft.com/en-gb/library/ms182350(v=vs.140).aspx)
- Finalizer should also call base.Finalize() [*](https://msdn.microsoft.com/en-gb/library/ms182341(v=vs.140).aspx)

I don't have .NET Core installed so I don't know why build fails to recognize [Serializable](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/SerializableAttribute.cs)-attribute...