### PR TITLE
Removing obsolete API methods to progress on #152 Generalized api changes

### DIFF
--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -157,18 +157,10 @@ module MoreUtil =
 
 module IVar =
   module Now =
-    [<Obsolete "Just use the constructor.">]
-    let inline create () = IVar<'x> ()
-    [<Obsolete "Just use the constructor.">]
-    let inline createFull (x: 'x) = IVar<'x> (x)
-    [<Obsolete "Just use the constructor.">]
-    let inline createFailure (e: exn) = IVar<'x> (e)
     [<MethodImpl(MethodImplOptions.NoInlining)>]
     let isFull (xI: IVar<'x>) = xI.Full
     [<MethodImpl(MethodImplOptions.NoInlining)>]
     let get (xI: IVar<'x>) : 'x = xI.Get ()
-  [<Obsolete "Just use the constructor.">]
-  let create () = ctor Now.create ()
   let inline fill (xI: IVar<'x>) (x: 'x) = IVar<'x>.Fill (xI, x) :> Job<unit>
   let inline tryFill (xI: IVar<'x>) (x: 'x) =
     IVar<'x>.TryFill (xI, x) :> Job<unit>
@@ -832,17 +824,8 @@ module Alt =
 
 module Ch =
   module Now =
-    [<Obsolete "Just use the constructor.">]
-    let inline create () = Ch<'x> ()
     let send (xCh: Ch<'x>) (x: 'x) =
       Ch<'x>.Send (initGlobalScheduler (), xCh, x)
-  [<Obsolete "Will be removed.">]
-  module Global =
-    [<Obsolete "Renamed to `Ch.Now.send`.">]
-    let inline send (xCh: Ch<'x>) (x: 'x) =
-      Now.send xCh x
-  [<Obsolete "Just use the constructor.">]
-  let create () = ctor Ch<'x> ()
   let inline send (xCh: Ch<'x>) (x: 'x) = ChSend<'x> (xCh, x) :> Job<unit>
   module Try =
     let inline give (xCh: Ch<'x>) (x: 'x) = ChTryGive<'x> (xCh, x) :> Job<bool>
@@ -1215,16 +1198,6 @@ module Job =
      Handler.DoHandleNull (&wr, e)
     override xK'.DoWork (wr) = xK'.Term (&wr)
     override xK'.DoCont (wr, _) = xK'.Term (&wr)
-
-  [<Obsolete "Use the `Proc` abstraction.">]
-  let startWithFinalizerIgnore (fJ: Job<unit>) (xJ: Job<_>) =
-    {new Job<unit> () with
-      override uJ'.DoJob (wr, uK) =
-       Worker.Push (&wr, uK)
-       Job.Do (xJ, &wr, Finalizer<_> (wr.Scheduler, fJ))}
-  [<Obsolete "Use the `Proc` abstraction.">]
-  let inline startWithFinalizer fJ (uJ: Job<unit>) =
-    startWithFinalizerIgnore fJ uJ
 
   //////////////////////////////////////////////////////////////////////////////
 

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1913,15 +1913,6 @@ module Extensions =
   //////////////////////////////////////////////////////////////////////////////
 
   type Task with
-    [<Obsolete "Use `Job.awaitTask`">]
-    static member inline awaitJob (xT: Task<'x>) = Job.awaitTask xT
-    [<Obsolete "Use `Job.awaitUnitTask`">]
-    static member inline awaitJob (uT: Task) = Job.awaitUnitTask uT
-    [<Obsolete "Use `Job.bindTask`">]
-    static member inline bindJob (xT: Task<'x>, x2yJ: 'x -> #Job<'y>) = Job.bindTask x2yJ xT
-    [<Obsolete "Use `Job.bindUnitTask`">]
-    static member inline bindJob (uT: Task, u2xJ: unit -> #Job<'x>) = Job.bindUnitTask u2xJ uT
-
     static member startJob (xJ: Job<'x>) =
       {new Job<Task<'x>> () with
         override xTJ'.DoJob (wr, xTK) =

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1670,15 +1670,6 @@ module Cond =
 ////////////////////////////////////////////////////////////////////////////////
 
 module MVar =
-  module Now =
-    [<Obsolete "Just use the constructor.">]
-    let inline create () = MVar<'x> ()
-    [<Obsolete "Just use the constructor.">]
-    let inline createFull (x: 'x) = MVar<'x> (x)
-  [<Obsolete "Just use the constructor.">]
-  let create () = ctor Now.create ()
-  [<Obsolete "Just use the constructor.">]
-  let createFull x = ctor MVar<'x> x
   let inline fill (xM: MVar<'x>) (x: 'x) = MVarFill<'x> (xM, x) :> Job<unit>
   let inline take (xM: MVar<'x>) = xM :> Alt<'x>
   let inline read xM = MVarRead xM :> Alt<_>
@@ -2297,8 +2288,5 @@ type BoundedMb<'x> (capacity) =
   member t.Take = takeCh :> Alt<_>
 
 module BoundedMb =
-  [<Obsolete "Just use the constructor.">]
-  let inline create capacity = Job.thunk ^ fun () ->
-    BoundedMb<_> (capacity)
   let inline put (xB: BoundedMb<_>) x = xB.Put x
   let inline take (xB: BoundedMb<_>) = xB.Take

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -2256,8 +2256,6 @@ type EmbeddedJobBuilder () =
 
 module Latch =
   module Now =
-    [<MethodImpl(MethodImplOptions.NoInlining); Obsolete "Just use the constructor.">]
-    let create initial = Latch initial
     let inline increment (l: Latch) = l.Increment ()
   let inline decrement (l: Latch) = l.Decrement ()
   let inline await (l: Latch) = l :> Alt<_>

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1592,7 +1592,7 @@ module Proc =
 ////////////////////////////////////////////////////////////////////////////////
 
 [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
-module Timer =
+module internal Timer =
   [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
   module Global =
     type [<AllowNullLiteral>] WorkTimedUnitCont =

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -837,17 +837,8 @@ module Ch =
 
 module Mailbox =
   module Now =
-    [<Obsolete "Just use the constructor.">]
-    let inline create () = Mailbox<'x> ()
     let send (xMb: Mailbox<'x>) (x: 'x) =
       Mailbox<'x>.Send (initGlobalScheduler (), xMb, x)
-  [<Obsolete "Will be removed.">]
-  module Global =
-    [<Obsolete "Renamed to `Mailbox.Now.send`.">]
-    let inline send (xMb: Mailbox<'x>) (x: 'x) =
-      Now.send xMb x
-  [<Obsolete "Just use the constructor.">]
-  let create () = ctor Mailbox ()
   let inline send (xMb: Mailbox<'x>) (x: 'x) =
     MailboxSend<'x> (xMb, x) :> Job<unit>
   let inline take (xMb: Mailbox<'x>) = xMb :> Alt<'x>

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -1638,11 +1638,6 @@ module internal Timer =
 ////////////////////////////////////////////////////////////////////////////////
 
 module Lock =
-  module Now =
-    [<Obsolete "Just use the constructor.">]
-    let inline create () = Lock ()
-  [<Obsolete "Just use the constructor.">]
-  let create () = ctor Lock ()
   let inline duringFun (l: Lock) (xF: unit -> 'x) =
     LockDuringFun<'x> (l, xF) :> Job<'x>
   let inline duringJob (l: Lock) (xJ: Job<'x>) =

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -2202,12 +2202,6 @@ type JobBuilder () =
     Job.whileDoDelay u2b u2uJ
   member inline __.Zero () = Job.unit ()
 
-  [<Obsolete "`JobBuilder.Bind: Task * ... -> ...` will be removed, because it causes type inference issues.  Use e.g. `Job.awaitUnitTask`.">]
-  member inline __.Bind (uT: Task, u2xJ: unit -> Job<'x>) =
-    Job.bindUnitTask u2xJ uT
-  [<Obsolete "`JobBuilder.ReturnFrom: Task -> ...` will be removed, because it causes type inference issues.  Use e.g. `Job.awaitUnitTask`.">]
-  member inline __.ReturnFrom (uT: Task) = Job.awaitUnitTask uT
-
 ////////////////////////////////////////////////////////////////////////////////
 
 type EmbeddedJob<'x> = struct

--- a/Libs/Hopac/Hopac.fs
+++ b/Libs/Hopac/Hopac.fs
@@ -873,7 +873,7 @@ module Mailbox =
 
 module Job =
   [<Obsolete "`Job.Global` module will be removed. Use the `Hopac` module.">]
-  module Global =
+  module internal Global =
     [<Obsolete "`Job.Global` module will be removed. Use the `Hopac` module.">]
     let startWithActions eF xF xJ =
       Scheduler.startWithActions (initGlobalScheduler ()) eF xF xJ

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -1782,10 +1782,6 @@ module Latch =
 
   /// Immediate operations on latches.
   module Now =
-    /// Creates a new latch with the specified initial count.
-    [<Obsolete "Just use the constructor.">]
-    val create: initial: int -> Latch
-
     /// Increments the counter of the latch.
     val inline increment: Latch -> unit
 

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -289,33 +289,6 @@ module Job =
   /// start`.
   val startIgnore: Job<_>    -> Job<unit>
 
-  /// Creates a job that immediately starts running the given job as a separate
-  /// concurrent job like `start`, but also attaches a finalizer to the started
-  /// job.  The finalizer job is started as a separate job in case the started
-  /// job does not return succesfully or raise an exception and is garbage
-  /// collected.  If the job either returns normally or raises an exception, the
-  /// finalizer job is not started.  See also: `Proc`.
-#if DOC
-  ///
-  /// When a job in Hopac is aborted (see `abort`) or is, for example, blocked
-  /// waiting for communication on a channel that is no longer reachable, the
-  /// job can be garbage collected.  Most concurrent jobs should not need a
-  /// finalizer and can be garbage collected safely in case they are blocked
-  /// indefinitely or aborted.  However, in some cases it may be useful to be
-  /// able to detect, for debugging reasons, or handle, for fault tolerance, a
-  /// case where a job is garbage collected.  For fault tolerance the `Proc`
-  /// abstraction may be preferable.
-#endif
-  [<Obsolete "Use the `Proc` abstraction.">]
-  val inline startWithFinalizer:       finalizer: Job<unit> -> Job<unit> -> Job<unit>
-
-  /// Creates a job that immediately starts running the given job as a separate
-  /// concurrent job like `start`, but also attaches a finalizer to the started
-  /// job.  `startWithFinalizerIgnore finalizerJ xJ` is equivalent to
-  /// `Job.Ignore xJ |> startWithFinalizer finalizerJ`.
-  [<Obsolete "Use the `Proc` abstraction.">]
-  val startWithFinalizerIgnore: finalizer: Job<unit> -> Job<_>    -> Job<unit>
-
   //# Basic combinators
 
   /// Creates a job with the given result.  See also: `lift`, `thunk`, `unit`.
@@ -1585,21 +1558,6 @@ type Ch<'x> =
 
 /// Operations on synchronous channels.
 module Ch =
-  /// Operations bound to the global scheduler.
-  [<Obsolete "Will be removed.">]
-  module Global =
-    /// Sends the given value to the specified channel.  `Ch.Global.send xCh x`
-    /// is equivalent to `Ch.send xCh x |> Hopac.start`.
-    ///
-    /// Note that using this function in a job workflow is not optimal and you
-    /// should use `Ch.send` instead.
-    [<Obsolete "Renamed to `Ch.Now.send`.">]
-    val inline send: Ch<'x> -> 'x -> unit
-
-  /// Creates a job that creates a new channel.
-  [<Obsolete "Just use the constructor.">]
-  val create: unit -> Job<Ch<'x>>
-
   /// Creates an alternative that, at instantiation time, offers to give the
   /// given value on the given channel, and becomes available when another job
   /// offers to take the value.  See also: `*<-`.
@@ -1651,10 +1609,6 @@ module Ch =
 
   /// Immediate or non-workflow operations on synchronous channels.
   module Now =
-    /// Creates a new channel.
-    [<Obsolete "Just use the constructor.">]
-    val inline create: unit -> Ch<'x>
-
     /// Sends the given value to the specified channel.  `Ch.Now.send xCh x` is
     /// equivalent to `Ch.send xCh x |> Hopac.start`.
     ///
@@ -1701,10 +1655,6 @@ type IVar<'x> =
 
 /// Operations on write once variables.
 module IVar =
-  /// Creates a job that creates a new write once variable.
-  [<Obsolete "Just use the constructor.">]
-  val create: unit -> Job<IVar<'x>>
-
   /// Creates a job that writes the given value to the given write once
   /// variable.  It is an error to write to a single write once variable more
   /// than once.
@@ -1749,18 +1699,6 @@ module IVar =
 
   /// Immediate or non-workflow operations on write once variables.
   module Now =
-    /// Creates a new write once variable.
-    [<Obsolete "Just use the constructor.">]
-    val inline create:        unit -> IVar<'x>
-
-    /// Creates a new write once variable with the given value.
-    [<Obsolete "Just use the constructor.">]
-    val inline createFull:    'x   -> IVar<'x>
-
-    /// Creates a new write once variable with the given failure exception.
-    [<Obsolete "Just use the constructor.">]
-    val inline createFailure: exn  -> IVar<'x>
-
     /// Returns true iff the given write once variable has already been filled
     /// (either with a value or with a failure).
     ///

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -1354,7 +1354,7 @@ module Alt =
 
 /// Operations on a wall-clock timer.
 [<Obsolete "The `Timer` module will be removed.  Use the `Hopac` module.">]
-module Timer =
+module internal Timer =
 
   /// Operations on the global wall-clock timer.  The global timer is implicitly
   /// associated with the global scheduler.

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -2045,10 +2045,6 @@ type Lock =
 
 /// Operations on mutual exclusion locks.
 module Lock =
-  /// Creates a job that creates a new mutual exclusion lock.
-  [<Obsolete "Just use the constructor.">]
-  val create: unit -> Job<Lock>
-
   /// Creates a job that runs the given job so that the lock is held during the
   /// execution of the given job.
   val inline duringJob: Lock ->      Job<'x> -> Job<'x>
@@ -2056,13 +2052,6 @@ module Lock =
   /// Creates a job that calls the given function so that the lock is held
   /// during the execution of the function.
   val inline duringFun: Lock -> (unit -> 'x) -> Job<'x>
-
-  /// Immediate or non-workflow operations on locks.
-  [<Obsolete "Will be removed.">]
-  module Now =
-    /// Creates a new lock.
-    [<Obsolete "Just use the constructor.">]
-    val inline create: unit -> Lock
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -1862,16 +1862,6 @@ type MVar<'x> =
 
 /// Operations on serialized variables.
 module MVar =
-  /// Creates a job that creates a new serialized variable that is initially
-  /// empty.
-  [<Obsolete "Just use the constructor.">]
-  val create: unit -> Job<MVar<'x>>
-
-  /// Creates a job that creates a new serialized variable that initially
-  /// contains the given value.
-  [<Obsolete "Just use the constructor.">]
-  val createFull: 'x -> Job<MVar<'x>>
-
   //# Primitives
 
   /// Creates a job that writes the given value to the serialized variable.  It
@@ -1952,18 +1942,6 @@ module MVar =
   /// with its original value before propagating the exception.
   val inline tryModifyFun: ('x ->      'x * 'y)  -> MVar<'x> -> Alt<'y>
 
-  /// Immediate or non-workflow operations on serialized variables.
-  [<Obsolete "Will be removed.">]
-  module Now =
-    /// Creates a new serialized variable that is initially empty.
-    [<Obsolete "Just use the constructor.">]
-    val inline create:     unit -> MVar<'x>
-
-    /// Creates a new serialized variable that initially contains the given
-    /// value.
-    [<Obsolete "Just use the constructor.">]
-    val inline createFull: 'x   -> MVar<'x>
-
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Represents a bounded synchronous mailbox for many to many communication.
@@ -1995,12 +1973,6 @@ type BoundedMb<'x> =
 
 /// Operations on bounded synchronous mailboxes.
 module BoundedMb =
-  /// Returns a job that creates a new bounded mailbox with a buffer of the
-  /// specified maximum capacity.  Note that a bounded mailbox with a capacity
-  /// of `0` behaves exactly the same as a channel, `Ch<_>`.
-  [<Obsolete "Just use the constructor.">]
-  val inline create: capacity: int -> Job<BoundedMb<'x>>
-
   /// Selective synchronous operation to put a message to a bounded mailbox.
   /// `put` operations are processed in FIFO order and become enabled as soon as
   /// there is room in the bounded buffer.  If the buffer capacity is `0`, `put`

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -2006,21 +2006,6 @@ type Mailbox<'x> =
 
 /// Operations on buffered mailboxes.
 module Mailbox =
-  /// Operations bound to the global scheduler.
-  [<Obsolete "Will be removed.">]
-  module Global =
-    /// Sends the given value to the specified mailbox.  `Mailbox.Global.send
-    /// xMb x` is equivalent to `Mailbox.send xMb x |> Hopac.start`.
-    ///
-    /// Note that using this function in a job workflow is not optimal and you
-    /// should use `Mailbox.send` instead.
-    [<Obsolete "Renamed to `Mailbox.Now.send`.">]
-    val inline send: Mailbox<'x> -> 'x -> unit
-
-  /// Creates a job that creates a new mailbox.
-  [<Obsolete "Just use the constructor.">]
-  val create: unit -> Job<Mailbox<'x>>
-
   /// Creates a job that sends the given value to the specified mailbox.  This
   /// operation never blocks.  See also: `*<<+`.
   val inline send: Mailbox<'x> -> 'x -> Job<unit>
@@ -2031,10 +2016,6 @@ module Mailbox =
 
   /// Immediate or non-workflow operations on buffered mailboxes.
   module Now =
-    /// Creates a new mailbox.
-    [<Obsolete "Just use the constructor.">]
-    val inline create: unit -> Mailbox<'x>
-
     /// Sends the given value to the specified mailbox.  `Mailbox.Now.send xMb
     /// x` is equivalent to `Mailbox.send xMb x |> Hopac.start`.
     ///

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -2856,10 +2856,6 @@ type JobBuilder =
   member inline While: (unit -> bool) * (unit -> Job<unit>) -> Job<unit>
   ///
   member inline Zero: unit -> Job<unit>
-  [<Obsolete "`JobBuilder.Bind: Task * ... -> ...` will be removed, because it causes type inference issues.  Use e.g. `Job.awaitUnitTask`.">]
-  member inline Bind:        Task     * (unit -> Job<'y>) -> Job<'y>
-  [<Obsolete "`JobBuilder.ReturnFrom: Task -> ...` will be removed, because it causes type inference issues.  Use e.g. `Job.awaitUnitTask`.">]
-  member inline ReturnFrom:        Task     -> Job<unit>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -2308,15 +2308,6 @@ module Extensions =
   /// comonadic while jobs are monadic.
 #endif
   type Task with
-    [<Obsolete "Use `Job.awaitTask`">]
-    static member inline awaitJob: Task<'x> -> Job<'x>
-    [<Obsolete "Use `Job.awaitUnitTask`">]
-    static member inline awaitJob: Task -> Job<unit>
-    [<Obsolete "Use `Job.bindTask`">]
-    static member inline bindJob: Task<'x> * ('x   -> #Job<'y>) -> Job<'y>
-    [<Obsolete "Use `Job.bindUnitTask`">]
-    static member inline bindJob: Task     * (unit -> #Job<'x>) -> Job<'x>
-
     /// Creates a job that starts the given job as a separate concurrent job,
     /// whose result can be obtained from the returned task.
     static member startJob: Job<'x> -> Job<Task<'x>>

--- a/Libs/Hopac/Hopac.fsi
+++ b/Libs/Hopac/Hopac.fsi
@@ -170,7 +170,7 @@ module Job =
   /// just one) where jobs are started or run outside of job workflows.
 #endif
   [<Obsolete "`Job.Global` module will be removed. Use the `Hopac` module.">]
-  module Global =
+  module internal Global =
     /// Queues the job for execution on the global scheduler.  See also:
     /// `start`, `server`.
 #if DOC

--- a/Libs/Hopac/TopLevel.fs
+++ b/Libs/Hopac/TopLevel.fs
@@ -11,60 +11,25 @@ module Hopac =
   let job = JobBuilder ()
   let onMain = Extensions.Async.Global.onMain ()
 
-  let inline run x = Job.Global.run x
+  let run x = Job.Global.run x
   let inline runDelay u2xJ = run <| Job.delay u2xJ
-  let inline startIgnore x = Job.Global.startIgnore x
-  let inline startDelay x = Job.Global.startIgnore <| Job.delay x
-  let inline start x = Job.Global.start x
-  let inline queueIgnore x = Job.Global.queueIgnore x
-  let inline queueDelay x = Job.Global.queueIgnore <| Job.delay x
-  let inline queue x = Job.Global.queue x
-  let inline server x = Job.Global.server x
+  let startIgnore x = Job.Global.startIgnore x
+  let startDelay x = Job.Global.startIgnore <| Job.delay x
+  let start x = Job.Global.start x
+  let queueIgnore x = Job.Global.queueIgnore x
+  let queueDelay x = Job.Global.queueIgnore <| Job.delay x
+  let queue x = Job.Global.queue x
+  let server x = Job.Global.server x
 
-  let inline queueAsTask x = Job.Global.queueAsTask x
-  let inline startAsTask x = Job.Global.startAsTask x
-  let inline startWithActions e2u x2u xJ = Job.Global.startWithActions e2u x2u xJ
+  let queueAsTask x = Job.Global.queueAsTask x
+  let startAsTask x = Job.Global.startAsTask x
+  let startWithActions e2u x2u xJ = Job.Global.startWithActions e2u x2u xJ
 
   let inline asAlt (xA: Alt<'x>) = xA
   let inline asJob (xJ: Job<'x>) = xJ
 
-  let inline timeOut x = Timer.Global.timeOut x
-  let inline timeOutMillis x = Timer.Global.timeOutMillis x
+  let timeOut x = Timer.Global.timeOut x
+  let timeOutMillis x = Timer.Global.timeOutMillis x
   let idle = Timer.Global.idle
 
   let inline memo (xJ: Job<'x>) = Promise<'x> xJ
-
-[<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-module TopLevel =
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  type Stream<'x> = Stream.Stream<'x>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let job = Hopac.job
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let onMain = Hopac.onMain
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline run x = Hopac.run x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline startIgnore x = Hopac.startIgnore x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline startDelay x = Hopac.startDelay x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline start x = Hopac.start x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline queueIgnore x = Hopac.queueIgnore x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline queueDelay x = Hopac.queueDelay x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline queue x = Hopac.queue x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline server x = Hopac.server x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline asAlt (xA: Alt<'x>) = xA
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline asJob (xJ: Job<'x>) = xJ
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline timeOut x = Hopac.timeOut x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline timeOutMillis x = Hopac.timeOutMillis x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  let inline memo x = Hopac.memo x

--- a/Libs/Hopac/TopLevel.fsi
+++ b/Libs/Hopac/TopLevel.fsi
@@ -38,15 +38,15 @@ module Hopac =
   /// Note that using this function in a job workflow is not optimal and you
   /// should use `Job.queue` instead.
 #endif
-  val inline queue:                Job<unit> -> unit
+  val queue:                Job<unit> -> unit
 
   /// Queues the given job for execution.  `queueIgnore xJ` is equivalent to
   /// `Job.Ignore xJ |> queue`.
-  val inline queueIgnore:          Job<_>    -> unit
+  val queueIgnore:          Job<_>    -> unit
 
   /// Queues the given delayed job for execution.  `queueDelay u2xJ` is
   /// equivalent to `queueIgnore <| Job.delay u2xJ`.
-  val inline queueDelay: (unit -> #Job<_>)   -> unit
+  val queueDelay: (unit -> #Job<_>)   -> unit
 
   /// Starts running the given job like `start`, but the given job is known
   /// never to return normally, so the job can be spawned in an even more
@@ -56,7 +56,7 @@ module Hopac =
   /// Note that using this function in a job workflow is not optimal and you
   /// should use `Job.server` instead.
 #endif
-  val inline server:               Job<Void> -> unit
+  val server:               Job<Void> -> unit
 
   /// Starts running the given job, but does not wait for the job to finish.
   /// See also: `queue`, `server`.
@@ -65,16 +65,16 @@ module Hopac =
   /// Note that using this function in a job workflow is not optimal and you
   /// should use `Job.start` instead.
 #endif
-  val inline start:                Job<unit> -> unit
+  val start:                Job<unit> -> unit
 
   /// Starts running the given job, but does not wait for the job to finish.
   /// `startIgnore xJ` is equivalent to `Job.Ignore xJ |> start`.
-  val inline startIgnore:          Job<_>    -> unit
+  val startIgnore:          Job<_>    -> unit
 
   /// Starts running the given delayed job, but does not wait for the job to
   /// finish.  `startDelay u2xJ` is equivalent to `startIgnore <| Job.delay
   /// u2xJ`.
-  val inline startDelay: (unit -> #Job<_>)   -> unit
+  val startDelay: (unit -> #Job<_>)   -> unit
 
   /// Starts running the given job and then blocks the current thread waiting
   /// for the job to either return successfully or fail.  See also: `start`.
@@ -97,7 +97,7 @@ module Hopac =
   /// needed, because within a workflow the result of a job can be obtained by
   /// binding.
 #endif
-  val inline run:                Job<'x>  -> 'x
+  val run:                Job<'x>  -> 'x
 
   /// `runDelay u2xJ` is equivalent to `run <| Job.delay u2xJ`.
   val inline runDelay: (unit -> #Job<'x>) -> 'x
@@ -106,11 +106,11 @@ module Hopac =
 
   /// Queues the given job for execution.  The result can be obtained from the
   /// returned task.
-  val inline queueAsTask: Job<'x> -> Task<'x>
+  val queueAsTask: Job<'x> -> Task<'x>
 
   /// Starts running the given job.  The result can be obtained from the
   /// returned task.
-  val inline startAsTask: Job<'x> -> Task<'x>
+  val startAsTask: Job<'x> -> Task<'x>
 
   /// Starts running the given job, but does not wait for the job to finish.
   /// Upon the failure or success of the job, one of the given actions is called
@@ -121,7 +121,7 @@ module Hopac =
   /// should instead use `Job.start` with the desired exception handling
   /// construct (e.g. `Job.tryIn` or `Job.catch`).
 #endif
-  val inline startWithActions: (exn -> unit) -> ('x -> unit) -> Job<'x> -> unit
+  val startWithActions: (exn -> unit) -> ('x -> unit) -> Job<'x> -> unit
 
   //# Timeouts
 
@@ -189,11 +189,11 @@ module Hopac =
   /// available.  See `idle` for an alternative that yields the thread of
   /// execution to any ready work before becoming available.
 #endif
-  val inline timeOut:       TimeSpan -> Alt<unit>
+  val timeOut:       TimeSpan -> Alt<unit>
 
   /// `timeOutMillis n` is equivalent to `timeOut << TimeSpan.FromMilliseconds
   /// <| float n`.
-  val inline timeOutMillis: int      -> Alt<unit>
+  val timeOutMillis: int      -> Alt<unit>
 
   /// Creates an alternative that yields the thread of execution to any ready
   /// work and then becomes available.
@@ -223,39 +223,4 @@ module Hopac =
 
   /// Use object as job.  This function is a NOP and is provided as a kind of
   /// syntactic alternative to using a type ascription or an `upcast`.
-  val inline asJob: Job<'x> -> Job<'x>
-
-[<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-module TopLevel =
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  type Stream<'x> = Stream.Stream<'x>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val job: JobBuilder
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val onMain: Extensions.Async.OnWithSchedulerBuilder
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline queue:                Job<unit> -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline queueIgnore:          Job<_>    -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline queueDelay: (unit -> #Job<_>)   -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline server:               Job<Void> -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline start:                Job<unit> -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline startIgnore:          Job<_>    -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline startDelay: (unit -> #Job<_>)   -> unit
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline run: Job<'x> -> 'x
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline timeOut:       TimeSpan -> Alt<unit>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline timeOutMillis: int      -> Alt<unit>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline memo: Job<'x> -> Promise<'x>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
-  val inline asAlt: Alt<'x> -> Alt<'x>
-  [<Obsolete "`TopLevel` has been renamed as `Hopac`.">]
   val inline asJob: Job<'x> -> Job<'x>

--- a/Tests/AdHocTests/BuilderTests.fs
+++ b/Tests/AdHocTests/BuilderTests.fs
@@ -18,7 +18,7 @@ let testSyntax (xT: Task<'disposable>)
   let! _ = xO
   let! _ = xT
   let! _ = xA
-  do! t
+  do! Job.awaitUnitTask t
   do! uJ
   if true then
     return ()
@@ -26,12 +26,12 @@ let testSyntax (xT: Task<'disposable>)
     ()
   try return! uJ
   with _ -> ()
-  try return! t
+  try return! Job.awaitUnitTask t
   finally ()
   let n = ref 1
   while !n > 0 do
     n := !n-1
-    return! t
+    return! Job.awaitUnitTask t
 #if !CORECLR
   use xT' = xT
   use! x = xT'


### PR DESCRIPTION
This is related to #152 

- Made Timer internal
- Made Job.Global internal
- Removed obsolete API methods from IVar, Ch, Latch, Lock, Mailbox, BoundedMb, Task, JobBuilder