### PR TITLE
fixed bottleneck in Stream.mapPipelinedJob

### DIFF
--- a/Libs/Hopac/Stream.fs
+++ b/Libs/Hopac/Stream.fs
@@ -540,7 +540,7 @@ module Stream =
             | Choice1Of2 y -> usage <- usage - 1
                               Cons (y, loop ())
             | Choice2Of2 e -> raise e
-          (if usage < degree then
+          (if not closing && usage < degree then
             inCh ^=> fun x ->
               usage <- usage + 1
               Job.tryInDelay 


### PR DESCRIPTION
This one fixes https://github.com/Hopac/Hopac/issues/185

Main idea is to not block `loop` on waiting for reply and be responsive to read replies from workers.
Old implementation had two steps on getting the reply:
* Got promise of result from mailbox
* Wait on that promise (it could not be ready yet) and stop looping. Meanwhile other jobs could be ready, so worker utilization was far from ideal

