### PR TITLE
fixing bash dependent directory removal

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -40,7 +40,7 @@ Target.create "Clean" (fun _ ->
   !!"./**/bin/"
   ++ "./**/obj/"
   |> Shell.cleanDirs
-  exec "rm" "-rf .gh-pages"
+  Directory.delete ".gh-pages"
 )
 
 let normaliseFileToLFEnding filename =


### PR DESCRIPTION
This one fixes #187 
Just using FAKE native directory removal instead of hardcoded bash comand