### PR TITLE
Fixed the incorrect operator usage.

### DIFF
--- a/Docs/Programming.md
+++ b/Docs/Programming.md
@@ -771,9 +771,9 @@ for starting and waiting for a sequence of jobs.  In this case we don't care
 about the results of the jobs, so `Job.conIgnore` is what we use:
 
 ```fsharp
-> [timeOut (TimeSpan.FromSeconds 0.0) >>-. hello "Hello, from first job!" ;
-   timeOut (TimeSpan.FromSeconds 0.3) >>-. hello "Hello, from second job!" ;
-   timeOut (TimeSpan.FromSeconds 0.6) >>-. hello "Hello, from third job"]
+> [timeOut (TimeSpan.FromSeconds 0.0) >>=. hello "Hello, from first job!" ;
+   timeOut (TimeSpan.FromSeconds 0.3) >>=. hello "Hello, from second job!" ;
+   timeOut (TimeSpan.FromSeconds 0.6) >>=. hello "Hello, from third job"]
 |> Job.conIgnore |> run ;;
 Hello, from first job!
 Hello, from second job!


### PR DESCRIPTION
Using `>>-.` leads to the results being ignored since it results in a `Job<Job<unit>> list` argument being passed to `Job.conIgnore`.

```fsharp
open Hopac
open Hopac.Infixes
open System

let hello what = job {
  for i=1 to 3 do
    do! timeOut (TimeSpan.FromSeconds 1.0)
    do printfn "%s" what
}

[
timeOut (TimeSpan.FromSeconds 0.0) >>=. hello "Hello, from first job!"
timeOut (TimeSpan.FromSeconds 0.3) >>=. hello "Hello, from second job!"
timeOut (TimeSpan.FromSeconds 0.6) >>=. hello "Hello, from third job"
] |> Job.conIgnore |> run
```

Here as example if you do not feel like writing it out.