### PR TITLE
Fixed flag shadowing

### DIFF
--- a/Libs/Hopac.Core/Hopac.Core.csproj
+++ b/Libs/Hopac.Core/Hopac.Core.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>NO_ISTHREADPOOLTHREAD</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_ISTHREADPOOLTHREAD</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This fixes pretty severe regression which was introduced 3 years ago with flags shadowing.
`TRAMPOLINE` and `AGGRESSIVE_INLINING` flags were always discarded

https://github.com/Hopac/Hopac/commit/200b5059ebc9fbd777a10d962a92196374f93da9#diff-d917cd509e30c9d77f29dc9648562ffebb37b41850d1af3aa790a637afd53793

# Repro

Before
```
dotnet run -c Release --project .\Benchmarks\AsyncOverhead\
Job.fromAsync: 100 hops in 00:00:00.0423154
Job.fromAsync: 1000 hops in 00:00:00.0022036
Job.fromAsync: Stack overflow.
```

After
```
dotnet run -c Release --project .\Benchmarks\AsyncOverhead\
Job.fromAsync: 100 hops in 00:00:00.0449605
Job.fromAsync: 1000 hops in 00:00:00.0019473
Job.fromAsync: 10000 hops in 00:00:00.0178911
Job.fromAsync: 100000 hops in 00:00:00.1666933
Job.fromAsync: 1000000 hops in 00:00:01.0097547
Job.fromAsync: 10000000 hops in 00:00:09.6868255
```